### PR TITLE
fix(llms): complete streamed chat tool calls

### DIFF
--- a/docs/design/octobus_integration.md
+++ b/docs/design/octobus_integration.md
@@ -19,15 +19,19 @@ capset IDs continue to use the daemon-wide gateway described here.
 
 ## Architecture
 
-Two paths:
+Three paths:
 
 ```text
-Control plane (frontend read, Connect/HTTP): frontend -> agent-compose CapabilityService -> OctoBus /admin/v1/*
-Data plane (agent call, gRPC):              guest agent -> agent-compose capproxy -> OctoBus daemon gRPC
+Control plane (frontend read, Connect/HTTP):   frontend -> agent-compose CapabilityService -> OctoBus /admin/v1/*
+Business invocation (Connect/HTTP):            business service -> agent-compose CapabilityService -> OctoBus Connect RPC
+Agent data plane (gRPC):                       guest agent -> agent-compose capproxy -> OctoBus daemon gRPC
 ```
 
-- The control plane is read-only: connection status, capability set list, and
-  capability catalog.
+- The control plane provides read-only connection status, capability set list,
+  and capability catalog.
+- Business invocation is deterministic and forwards an explicit
+  `capset/instance/service/method/payload` request without involving an agent
+  or model.
 - The data plane exposes only gRPC: guest calls capabilities through
   agent-compose transparent proxy. MCP / REST are not exposed to the guest.
 - Both paths resolve an OctoBus target at call time. Unqualified capsets
@@ -50,25 +54,30 @@ UI shows only product concepts:
 
 Page-configured, stored in DB, dynamically read at runtime:
 
-- Table `capability_gateway`, single row: `addr`, `token` (secret).
+- Table `capability_gateway`, single row: `addr`, `token` (capset invocation
+  secret), and `admin_token` (OctoBus admin API secret).
 - `ConfigService` provides `GetCapabilityGatewayConfig` /
-  `UpdateCapabilityGatewayConfig`; token is redacted when read back.
+  `UpdateCapabilityGatewayConfig`; both tokens are redacted when read back.
 - Non-empty `addr` means enabled.
 
 ```proto
 message CapabilityGatewayConfig {   // read response, never returns token
   string addr = 1;
-  bool token_set = 2;               // whether token is set
+  bool token_set = 2;               // whether the capset token is set
+  bool admin_token_set = 3;         // whether the admin token is set
 }
 
 message UpdateCapabilityGatewayConfigRequest {
-  string addr = 1;
-  string token = 2;                 // empty string means clear
+  optional string addr = 1;
+  optional string token = 2;        // capset token; empty string means clear
+  optional string admin_token = 3;  // admin token; empty string means clear
 }
 ```
 
-When backend accesses OctoBus, it injects `Authorization: Bearer <token>` if
-token exists. Token stays server-side only; it is not returned to frontend in
+Admin API reads (`/admin/v1/status`, capsets, and catalog) use `admin_token`.
+When `admin_token` is empty, the legacy `token` value is used only as a
+compatibility fallback. Business `InvokeCapability` calls always use `token`.
+Both values stay server-side only; neither is returned to the frontend in
 plaintext, written into sandbox metadata, injected into guest env, or logged.
 
 This singleton remains the compatibility route for every unqualified
@@ -100,6 +109,7 @@ service CapabilityService {
   rpc GetCapabilityStatus(GetCapabilityStatusRequest) returns (CapabilityStatusResponse);
   rpc ListCapabilitySets(ListCapabilitySetsRequest) returns (ListCapabilitySetsResponse);
   rpc GetCapabilityCatalog(GetCapabilityCatalogRequest) returns (GetCapabilityCatalogResponse);
+  rpc InvokeCapability(InvokeCapabilityRequest) returns (InvokeCapabilityResponse);
 }
 
 message GetCapabilityStatusRequest {}
@@ -152,6 +162,17 @@ message GetCapabilityCatalogResponse {
   string description = 3;
   repeated CapabilityMethod methods = 4;
 }
+
+message InvokeCapabilityRequest {
+  string capset_id = 1;
+  string instance_id = 2;
+  string service_id = 3;
+  string method = 4;
+  string payload_json = 5;
+}
+message InvokeCapabilityResponse {
+  string result_json = 1;
+}
 ```
 
 Backend behavior:
@@ -161,6 +182,7 @@ Backend behavior:
 | `GetCapabilityStatus` | `GET /admin/v1/status` | Return `configured` / `ok` / `status` / `service_count` |
 | `ListCapabilitySets` | `GET /admin/v1/capsets` | Normalize to UI capability set list |
 | `GetCapabilityCatalog` | `GET /admin/v1/catalog/{capset_id}?all=true` | Backend performs URL escaping and normalizes the three protocol entries |
+| `InvokeCapability` | `POST /capsets/{capset_id}/connect/{instance_id}/{service_id}/{method}` | Forward the JSON request to OctoBus and return the JSON response |
 
 The same catalog endpoint also provides `?format=md` (`text/markdown`, rendered
 by OctoBus `RenderCatalogMarkdown`). During sandbox injection, agent-compose
@@ -329,7 +351,7 @@ Injection chain:
 Settings page "Capability Gateway":
 
 - `GetCapabilityGatewayConfig` / `UpdateCapabilityGatewayConfig` edit
-  `addr` / `token`.
+  `addr`, the capset invocation token, and the OctoBus admin token.
 - `GetCapabilityStatus` probes connection status and capability count.
 
 Sandbox creation and scheduler:
@@ -356,14 +378,14 @@ client uses timeout.
 
 Backend:
 
-1. Add `capability_gateway` table to `ConfigStore` with single row `addr` and
-   `token`, plus `Get` / `Save`.
+1. Add `capability_gateway` table to `ConfigStore` with single row `addr`,
+   `token`, and `admin_token`, plus `Get` / `Save`.
 2. Proto: add `GetCapabilityGatewayConfig` /
    `UpdateCapabilityGatewayConfig` to `SettingsService`; add `capset_ids` to
    `AgentSpec` and sandbox request shapes; add three
    `CapabilityService` RPCs. Regenerate Go / TS.
-3. Control-plane provider depends on `ConfigStore` and reads `addr` / `token`
-   on every call.
+3. Control-plane provider depends on `ConfigStore` and reads `addr` /
+   `admin_token` on every call.
 4. Data-plane capproxy: read OctoBus addr / token from `ConfigStore`; maintain
    token -> sandbox in-memory index; validate guest `x-octobus-capset` belongs
    to sandbox binding; require guest `x-octobus-instance` for business calls;

--- a/docs/pages/octobus-quickstart.md
+++ b/docs/pages/octobus-quickstart.md
@@ -8,7 +8,7 @@ For configuration field reference, see the [agent-compose.yml Manual](https://gi
 
 | Concept | What it is | Who owns it |
 | --- | --- | --- |
-| **Capability Gateway** | The OctoBus connection configured in the agent-compose settings page (`addr` + `token`). | agent-compose daemon |
+| **Capability Gateway** | The OctoBus connection configured in the agent-compose settings page (`addr` plus admin and capset tokens). | agent-compose daemon |
 | **capset** | A named set of capabilities published by OctoBus, composed of `capset -> service -> instance -> method` bindings. | OctoBus |
 | **`capset_ids`** | The agent field that declares which capsets its sandboxes may use. | Your `agent-compose.yml` |
 | **capability proxy (capproxy)** | A gRPC proxy inside the daemon. Sandboxes never talk to OctoBus directly; capproxy checks authorization and forwards calls. | agent-compose daemon |
@@ -23,6 +23,21 @@ guest agent ──gRPC──▶ capproxy (CAP_GRPC_TARGET) ──gRPC──▶ O
 ```
 
 The guest only ever sees `CAP_GRPC_TARGET` and `CAP_TOKEN`. The OctoBus address and token stay inside the daemon and never enter the sandbox.
+
+## Business requests through agent-compose
+
+Agents use the gRPC capability proxy described below. Separately, a business
+service can call an OctoBus Connect RPC method through the deterministic
+`CapabilityService.InvokeCapability` API. The request names the capset, instance,
+service, method, and JSON payload. agent-compose resolves the configured
+OctoBus connection, injects the capset invocation token, and forwards the
+request to OctoBus. No agent or model participates in this path.
+
+```text
+business service
+  -> agent-compose /agentcompose.v2.CapabilityService/InvokeCapability
+  -> OctoBus Connect RPC
+```
 
 ## Prerequisites
 
@@ -87,11 +102,18 @@ Two independent things must both be configured:
 Open the web UI, go to **Settings → Capability Gateway**, and set:
 
 - **Address**: the OctoBus admin API address as reachable from the daemon container, e.g. `http://octobus:9000` (Docker network) or `http://host.docker.internal:9000` (OctoBus on the host).
-- **Token**: the capset/daemon token if you configured one in Step 2; leave empty otherwise.
+- **Admin Token (OctoBus Admin Token)**: the token used for OctoBus
+  `/admin/v1/*` reads. Leave empty only if the admin API is unprotected.
+- **Capability Invocation Token (Capset Token)**: the capset access token from
+  Step 2, used only for `InvokeCapability`; leave empty only if the capset is
+  public.
 
 The settings page immediately probes `GET /admin/v1/status` on OctoBus and shows the connection status and the number of published capability sets. A green status with your `dev` capset listed means the control plane is wired correctly.
 
-The token is stored by the daemon only: it is redacted on read-back, never written into sandbox metadata, never injected into guest env, and never logged.
+Both tokens are stored by the daemon only: they are redacted on read-back,
+never written into sandbox metadata, never injected into guest env, and never
+logged. The admin token and capset token are independent and should not be
+interchanged.
 
 ### 3b. Capability proxy (data plane)
 

--- a/docs/pages/zh-CN/octobus-quickstart.md
+++ b/docs/pages/zh-CN/octobus-quickstart.md
@@ -8,7 +8,7 @@
 
 | 概念 | 含义 | 归属方 |
 | --- | --- | --- |
-| **Capability Gateway（能力网关）** | 在 agent-compose 设置页配置的 OctoBus 连接（`addr` + `token`）。 | agent-compose daemon |
+| **Capability Gateway（能力网关）** | 在 agent-compose 设置页配置的 OctoBus 连接（`addr`，以及管理 Token 和 Capset Token）。 | agent-compose daemon |
 | **capset（能力集）** | OctoBus 发布的一组能力，由 `capset -> service -> instance -> method` 绑定构成。 | OctoBus |
 | **`capset_ids`** | Agent 配置字段，声明其沙箱允许使用哪些能力集。 | 你的 `agent-compose.yml` |
 | **capability proxy（capproxy）** | daemon 内部的 gRPC 代理。沙箱从不直接连接 OctoBus，由 capproxy 做鉴权检查并转发调用。 | agent-compose daemon |
@@ -23,6 +23,20 @@ guest agent ──gRPC──▶ capproxy (CAP_GRPC_TARGET) ──gRPC──▶ O
 ```
 
 guest 只能看到 `CAP_GRPC_TARGET` 和 `CAP_TOKEN`。OctoBus 的地址和 token 始终留在 daemon 内，不会进入沙箱。
+
+## 业务请求通过 agent-compose 调用 OctoBus
+
+Agent 使用后文描述的 gRPC 能力代理。除此之外，业务服务还可以通过确定性的
+`CapabilityService.InvokeCapability` 接口调用 OctoBus Connect RPC 方法。
+请求显式指定 capset、instance、service、method 和 JSON payload；
+agent-compose 读取已配置的 OctoBus 连接，注入 Capset Token 后转发给
+OctoBus。这条路径不经过 Agent，也不调用模型。
+
+```text
+业务服务
+  -> agent-compose /agentcompose.v2.CapabilityService/InvokeCapability
+  -> OctoBus Connect RPC
+```
 
 ## 前置条件
 
@@ -87,11 +101,16 @@ octobus catalog dev --all --json
 打开 Web UI，进入 **Settings → Capability Gateway**，设置：
 
 - **地址（Address）**：从 daemon 容器视角可达的 OctoBus admin API 地址，例如 `http://octobus:9000`（Docker 网络）或 `http://host.docker.internal:9000`（OctoBus 跑在宿主机）。
-- **Token**：如果你在第 2 步配置了能力集 token 就填上，否则留空。
+- **管理 Token（OctoBus Admin Token）**：用于读取 OctoBus
+  `/admin/v1/*` 的管理 Token。只有管理 API 未受保护时才留空。
+- **能力调用 Token（Capset Token）**：第 2 步配置的 Capset 访问 Token，
+  只用于 `InvokeCapability`。只有 Capset 公开访问时才留空。
 
 设置页会立即探测 OctoBus 的 `GET /admin/v1/status`，并显示连接状态和已发布能力集数量。状态为绿色且能看到 `dev` 能力集，说明控制面已经接通。
 
-token 只保存在 daemon：读取时会被脱敏，不会写入沙箱元数据、不会注入 guest 环境变量、不会进入日志。
+两类 Token 都只保存在 daemon：读取时会被脱敏，不会写入沙箱元数据、
+不会注入 guest 环境变量、不会进入日志。管理 Token 与 Capset Token
+相互独立，不能混用。
 
 ### 3b. 能力代理（数据面）
 

--- a/pkg/agentcompose/adapters/session_rpc_bridge_test.go
+++ b/pkg/agentcompose/adapters/session_rpc_bridge_test.go
@@ -106,6 +106,10 @@ func (p testCapabilityProvider) CapabilityGuide(ctx context.Context, capsetID st
 	return p.guide(ctx, capsetID)
 }
 
+func (p testCapabilityProvider) InvokeConnect(context.Context, capability.InvokeRequest) (json.RawMessage, error) {
+	return nil, capability.ErrNotConfigured
+}
+
 func (p testCapabilityProvider) ProxyTarget() string {
 	return p.target
 }

--- a/pkg/agentcompose/api/capability_error.go
+++ b/pkg/agentcompose/api/capability_error.go
@@ -21,6 +21,8 @@ func CapabilityConnectError(err error) error {
 		return connect.NewError(connect.CodeFailedPrecondition, err)
 	case errors.Is(err, capability.ErrInvalidCatalog):
 		return connect.NewError(connect.CodeInvalidArgument, err)
+	case errors.Is(err, capability.ErrInvalidInvoke):
+		return connect.NewError(connect.CodeInvalidArgument, err)
 	case errors.As(err, &upstream):
 		return connect.NewError(octoBusConnectCode(upstream), err)
 	default:

--- a/pkg/agentcompose/api/capability_error_test.go
+++ b/pkg/agentcompose/api/capability_error_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 	"testing"
@@ -196,8 +197,47 @@ func TestListCapabilitySetsPreservesOctoBusErrorCode(t *testing.T) {
 	}
 }
 
+func TestInvokeCapabilityForwardsRequestAndPreservesResponse(t *testing.T) {
+	provider := &capabilityErrorProvider{
+		invokeResult: json.RawMessage(`{"response_code":0,"data":{"kind":"ip"}}`),
+	}
+	handler := NewCapabilityV2Handler(provider, nil)
+
+	response, err := handler.InvokeCapability(context.Background(), connect.NewRequest(&agentcomposev2.InvokeCapabilityRequest{
+		CapsetId:    "threat-intel",
+		InstanceId:  "cloud",
+		ServiceId:   "ThreatBook.Cloud",
+		Method:      "IpReputation",
+		PayloadJson: `{"resource":"8.8.8.8"}`,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.Msg.GetResultJson() != `{"response_code":0,"data":{"kind":"ip"}}` {
+		t.Fatalf("result_json = %s", response.Msg.GetResultJson())
+	}
+	if provider.invokeRequest.CapsetID != "threat-intel" ||
+		provider.invokeRequest.InstanceID != "cloud" ||
+		provider.invokeRequest.ServiceID != "ThreatBook.Cloud" ||
+		provider.invokeRequest.Method != "IpReputation" ||
+		string(provider.invokeRequest.Payload) != `{"resource":"8.8.8.8"}` {
+		t.Fatalf("invoke request = %+v", provider.invokeRequest)
+	}
+}
+
+func TestInvokeCapabilityMapsInvalidInvoke(t *testing.T) {
+	handler := NewCapabilityV2Handler(&capabilityErrorProvider{invokeErr: capability.ErrInvalidInvoke}, nil)
+	_, err := handler.InvokeCapability(context.Background(), connect.NewRequest(&agentcomposev2.InvokeCapabilityRequest{}))
+	if connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("InvokeCapability code = %s, want %s; err=%v", connect.CodeOf(err), connect.CodeInvalidArgument, err)
+	}
+}
+
 type capabilityErrorProvider struct {
-	listErr error
+	listErr       error
+	invokeErr     error
+	invokeResult  json.RawMessage
+	invokeRequest capability.InvokeRequest
 }
 
 func (p *capabilityErrorProvider) Status(context.Context) capability.Status {
@@ -214,6 +254,11 @@ func (p *capabilityErrorProvider) Catalog(context.Context, string) (capability.C
 
 func (p *capabilityErrorProvider) CapabilityGuide(context.Context, string) ([]byte, error) {
 	return nil, nil
+}
+
+func (p *capabilityErrorProvider) InvokeConnect(_ context.Context, request capability.InvokeRequest) (json.RawMessage, error) {
+	p.invokeRequest = request
+	return p.invokeResult, p.invokeErr
 }
 
 func (p *capabilityErrorProvider) ProxyTarget() string { return "" }

--- a/pkg/agentcompose/api/capability_invoke_test.go
+++ b/pkg/agentcompose/api/capability_invoke_test.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/chaitin/agent-compose/pkg/capabilities"
+	domain "github.com/chaitin/agent-compose/pkg/model"
+	agentcomposev2connect "github.com/chaitin/agent-compose/proto/agentcompose/v2/agentcomposev2connect"
+)
+
+type capabilityGatewaySource struct {
+	settings domain.CapabilityGatewaySettings
+}
+
+func (s capabilityGatewaySource) GetCapabilityGateway(context.Context) (domain.CapabilityGatewaySettings, error) {
+	return s.settings, nil
+}
+
+func TestInvokeCapabilityForwardsOverConnect(t *testing.T) {
+	var (
+		gotAuthorization string
+		gotPath          string
+		gotBody          map[string]any
+	)
+	octobus := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthorization = r.Header.Get("Authorization")
+		gotPath = r.URL.EscapedPath()
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = w.Write([]byte(`{"response_code":0,"data":{"kind":"ip"}}`))
+	}))
+	defer octobus.Close()
+
+	provider := capabilities.NewDynamicProvider(capabilityGatewaySource{
+		settings: domain.CapabilityGatewaySettings{
+			Addr:  octobus.URL,
+			Token: "octobus-secret",
+		},
+	}, "")
+	path, handler := agentcomposev2connect.NewCapabilityServiceHandler(NewCapabilityV2Handler(provider, nil))
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	body := `{"capsetId":"threat-intel","instanceId":"cloud","serviceId":"ThreatBook.Cloud","method":"IpReputation","payloadJson":"{\"resource\":\"8.8.8.8\"}"}`
+	response, err := http.Post(server.URL+path+"InvokeCapability", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", response.StatusCode)
+	}
+	var decoded struct {
+		ResultJSON string `json:"resultJson"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.ResultJSON != `{"response_code":0,"data":{"kind":"ip"}}` {
+		t.Fatalf("resultJson = %s", decoded.ResultJSON)
+	}
+	if gotAuthorization != "Bearer octobus-secret" {
+		t.Fatalf("authorization = %q", gotAuthorization)
+	}
+	if gotPath != "/capsets/threat-intel/connect/cloud/ThreatBook.Cloud/IpReputation" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotBody["resource"] != "8.8.8.8" {
+		t.Fatalf("body = %+v", gotBody)
+	}
+}

--- a/pkg/agentcompose/api/capability_v2.go
+++ b/pkg/agentcompose/api/capability_v2.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 
 	"connectrpc.com/connect"
@@ -52,6 +53,19 @@ func (h *CapabilityV2Handler) GetCapabilityCatalog(ctx context.Context, req *con
 		return nil, CapabilityConnectError(err)
 	}
 	return connect.NewResponse(capabilityCatalogV2(item)), nil
+}
+func (h *CapabilityV2Handler) InvokeCapability(ctx context.Context, req *connect.Request[agentcomposev2.InvokeCapabilityRequest]) (*connect.Response[agentcomposev2.InvokeCapabilityResponse], error) {
+	result, err := h.provider.InvokeConnect(ctx, capability.InvokeRequest{
+		CapsetID:   req.Msg.GetCapsetId(),
+		InstanceID: req.Msg.GetInstanceId(),
+		ServiceID:  req.Msg.GetServiceId(),
+		Method:     req.Msg.GetMethod(),
+		Payload:    json.RawMessage(strings.TrimSpace(req.Msg.GetPayloadJson())),
+	})
+	if err != nil {
+		return nil, CapabilityConnectError(err)
+	}
+	return connect.NewResponse(&agentcomposev2.InvokeCapabilityResponse{ResultJson: string(result)}), nil
 }
 func capabilityCatalogV2(item capability.Catalog) *agentcomposev2.GetCapabilityCatalogResponse {
 	response := &agentcomposev2.GetCapabilityCatalogResponse{CapsetId: item.CapsetID, Name: item.Name, Description: item.Description}

--- a/pkg/agentcompose/api/settings_v2.go
+++ b/pkg/agentcompose/api/settings_v2.go
@@ -73,7 +73,11 @@ func (h *SettingsV2Handler) GetCapabilityGatewayConfig(ctx context.Context, _ *c
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	return connect.NewResponse(&agentcomposev2.GetCapabilityGatewayConfigResponse{Config: &agentcomposev2.CapabilityGatewayConfig{Addr: settings.Addr, TokenSet: strings.TrimSpace(settings.Token) != ""}}), nil
+	return connect.NewResponse(&agentcomposev2.GetCapabilityGatewayConfigResponse{Config: &agentcomposev2.CapabilityGatewayConfig{
+		Addr:          settings.Addr,
+		TokenSet:      strings.TrimSpace(settings.Token) != "",
+		AdminTokenSet: strings.TrimSpace(settings.AdminToken) != "",
+	}}), nil
 }
 func (h *SettingsV2Handler) UpdateCapabilityGatewayConfig(ctx context.Context, req *connect.Request[agentcomposev2.UpdateCapabilityGatewayConfigRequest]) (*connect.Response[agentcomposev2.UpdateCapabilityGatewayConfigResponse], error) {
 	current, err := h.store.GetCapabilityGateway(ctx)
@@ -86,11 +90,18 @@ func (h *SettingsV2Handler) UpdateCapabilityGatewayConfig(ctx context.Context, r
 	if req.Msg.Token != nil {
 		current.Token = req.Msg.GetToken()
 	}
+	if req.Msg.AdminToken != nil {
+		current.AdminToken = req.Msg.GetAdminToken()
+	}
 	saved, err := h.store.SaveCapabilityGateway(ctx, current)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
-	return connect.NewResponse(&agentcomposev2.UpdateCapabilityGatewayConfigResponse{Config: &agentcomposev2.CapabilityGatewayConfig{Addr: saved.Addr, TokenSet: strings.TrimSpace(saved.Token) != ""}}), nil
+	return connect.NewResponse(&agentcomposev2.UpdateCapabilityGatewayConfigResponse{Config: &agentcomposev2.CapabilityGatewayConfig{
+		Addr:          saved.Addr,
+		TokenSet:      strings.TrimSpace(saved.Token) != "",
+		AdminTokenSet: strings.TrimSpace(saved.AdminToken) != "",
+	}}), nil
 }
 func (h *SettingsV2Handler) ListWorkspacePresets(ctx context.Context, req *connect.Request[agentcomposev2.ListWorkspacePresetsRequest]) (*connect.Response[agentcomposev2.ListWorkspacePresetsResponse], error) {
 	items, err := h.store.ListWorkspaceConfigs(ctx)

--- a/pkg/agentcompose/api/settings_v2_test.go
+++ b/pkg/agentcompose/api/settings_v2_test.go
@@ -70,7 +70,52 @@ func TestSettingsGlobalEnvEmptyAndOmittedEntriesReplaceCollection(t *testing.T) 
 	}
 }
 
-type settingsStoreFake struct{ env []domain.SandboxEnvVar }
+func TestSettingsCapabilityGatewayTokensAreIndependent(t *testing.T) {
+	ctx := context.Background()
+	store := &settingsStoreFake{gateway: domain.CapabilityGatewaySettings{
+		Addr:       "http://octobus",
+		Token:      "capset-token",
+		AdminToken: "admin-token",
+	}}
+	handler := NewSettingsV2Handler(&appconfig.Config{DataRoot: t.TempDir()}, store)
+
+	configured, err := handler.GetCapabilityGatewayConfig(ctx, connect.NewRequest(&agentcomposev2.GetCapabilityGatewayConfigRequest{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !configured.Msg.GetConfig().GetTokenSet() || !configured.Msg.GetConfig().GetAdminTokenSet() {
+		t.Fatalf("configured tokens = %+v", configured.Msg.GetConfig())
+	}
+
+	empty := ""
+	if _, err := handler.UpdateCapabilityGatewayConfig(ctx, connect.NewRequest(&agentcomposev2.UpdateCapabilityGatewayConfigRequest{
+		AdminToken: &empty,
+	})); err != nil {
+		t.Fatal(err)
+	}
+	if store.gateway.Token != "capset-token" || store.gateway.AdminToken != "" {
+		t.Fatalf("gateway after admin clear = %+v", store.gateway)
+	}
+
+	replacement := "replacement-capset-token"
+	updated, err := handler.UpdateCapabilityGatewayConfig(ctx, connect.NewRequest(&agentcomposev2.UpdateCapabilityGatewayConfigRequest{
+		Token: &replacement,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store.gateway.Token != replacement || store.gateway.AdminToken != "" {
+		t.Fatalf("gateway after capset update = %+v", store.gateway)
+	}
+	if !updated.Msg.GetConfig().GetTokenSet() || updated.Msg.GetConfig().GetAdminTokenSet() {
+		t.Fatalf("updated token state = %+v", updated.Msg.GetConfig())
+	}
+}
+
+type settingsStoreFake struct {
+	env     []domain.SandboxEnvVar
+	gateway domain.CapabilityGatewaySettings
+}
 
 func (s *settingsStoreFake) ListGlobalEnv(context.Context) ([]domain.SandboxEnvVar, error) {
 	return append([]domain.SandboxEnvVar(nil), s.env...), nil
@@ -92,9 +137,10 @@ func (*settingsStoreFake) UpdateWorkspaceConfig(_ context.Context, item domain.W
 	return item, nil
 }
 func (*settingsStoreFake) DeleteWorkspaceConfig(context.Context, string) error { return nil }
-func (*settingsStoreFake) GetCapabilityGateway(context.Context) (domain.CapabilityGatewaySettings, error) {
-	return domain.CapabilityGatewaySettings{}, nil
+func (s *settingsStoreFake) GetCapabilityGateway(context.Context) (domain.CapabilityGatewaySettings, error) {
+	return s.gateway, nil
 }
-func (*settingsStoreFake) SaveCapabilityGateway(_ context.Context, item domain.CapabilityGatewaySettings) (domain.CapabilityGatewaySettings, error) {
+func (s *settingsStoreFake) SaveCapabilityGateway(_ context.Context, item domain.CapabilityGatewaySettings) (domain.CapabilityGatewaySettings, error) {
+	s.gateway = item
 	return item, nil
 }

--- a/pkg/capabilities/guide_test.go
+++ b/pkg/capabilities/guide_test.go
@@ -2,6 +2,7 @@ package capabilities
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -34,6 +35,9 @@ func (*guideTestProvider) Catalog(context.Context, string) (capability.Catalog, 
 func (p *guideTestProvider) CapabilityGuide(_ context.Context, id string) ([]byte, error) {
 	p.globalCalls = append(p.globalCalls, id)
 	return []byte("global"), nil
+}
+func (*guideTestProvider) InvokeConnect(context.Context, capability.InvokeRequest) (json.RawMessage, error) {
+	return nil, capability.ErrNotConfigured
 }
 func (*guideTestProvider) ProxyTarget() string { return "proxy:1" }
 func (p *guideTestProvider) CapabilityGuideForScope(_ context.Context, scope GuideScope, declaration string) ([]byte, error) {

--- a/pkg/capabilities/provider.go
+++ b/pkg/capabilities/provider.go
@@ -2,6 +2,7 @@ package capabilities
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -19,6 +20,7 @@ type Provider interface {
 	ListCapsets(context.Context) ([]capability.Capset, error)
 	Catalog(context.Context, string) (capability.Catalog, error)
 	CapabilityGuide(ctx context.Context, capsetID string) ([]byte, error)
+	InvokeConnect(context.Context, capability.InvokeRequest) (json.RawMessage, error)
 	ProxyTarget() string
 }
 
@@ -109,7 +111,11 @@ func (p *DynamicProvider) client(ctx context.Context) (*capability.Client, bool)
 	if err != nil || strings.TrimSpace(settings.Addr) == "" {
 		return nil, false
 	}
-	return capability.NewClient(capability.Config{Addr: settings.Addr, Token: settings.Token}), true
+	return capability.NewClient(capability.Config{
+		Addr:       settings.Addr,
+		Token:      settings.Token,
+		AdminToken: settings.AdminToken,
+	}), true
 }
 
 func (p *DynamicProvider) Status(ctx context.Context) capability.Status {
@@ -142,6 +148,14 @@ func (p *DynamicProvider) CapabilityGuide(ctx context.Context, capsetID string) 
 		return nil, capability.ErrNotConfigured
 	}
 	return client.CatalogMarkdown(ctx, capsetID)
+}
+
+func (p *DynamicProvider) InvokeConnect(ctx context.Context, request capability.InvokeRequest) (json.RawMessage, error) {
+	client, ok := p.client(ctx)
+	if !ok {
+		return nil, capability.ErrNotConfigured
+	}
+	return client.InvokeConnect(ctx, request)
 }
 
 func (p *DynamicProvider) ProxyTarget() string {

--- a/pkg/capability/client.go
+++ b/pkg/capability/client.go
@@ -17,6 +17,7 @@ const defaultTimeout = 5 * time.Second
 type Client struct {
 	addr       string
 	token      string
+	adminToken string
 	httpClient *http.Client
 }
 
@@ -28,6 +29,7 @@ func NewClient(config Config) *Client {
 	return &Client{
 		addr:       strings.TrimRight(strings.TrimSpace(config.Addr), "/"),
 		token:      strings.TrimSpace(config.Token),
+		adminToken: strings.TrimSpace(config.AdminToken),
 		httpClient: &http.Client{Timeout: timeout},
 	}
 }
@@ -98,8 +100,8 @@ func (c *Client) CatalogMarkdown(ctx context.Context, capsetID string) ([]byte, 
 		return nil, err
 	}
 	req.Header.Set("Accept", "text/markdown")
-	if c.token != "" {
-		req.Header.Set("Authorization", "Bearer "+c.token)
+	if token := c.adminAuthorizationToken(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -116,14 +118,77 @@ func (c *Client) CatalogMarkdown(ctx context.Context, capsetID string) ([]byte, 
 	return body, nil
 }
 
+func (c *Client) InvokeConnect(ctx context.Context, request InvokeRequest) (json.RawMessage, error) {
+	if !c.Configured() {
+		return nil, ErrNotConfigured
+	}
+	capsetID, instanceID, serviceID, method, payload, err := normalizeInvokeRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	path := "/capsets/" + url.PathEscape(capsetID) + "/connect/" +
+		url.PathEscape(instanceID) + "/" + url.PathEscape(serviceID) + "/" + url.PathEscape(method)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.addr+path, strings.NewReader(string(payload)))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Connect-Protocol-Version", "1")
+	req.Header.Set("Content-Type", "application/json")
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, octobusHTTPError(resp.StatusCode, body)
+	}
+	if !json.Valid(body) {
+		return nil, errors.New("octobus returned invalid JSON")
+	}
+	return json.RawMessage(body), nil
+}
+
+func normalizeInvokeRequest(request InvokeRequest) (string, string, string, string, json.RawMessage, error) {
+	capsetID := strings.TrimSpace(request.CapsetID)
+	instanceID := strings.TrimSpace(request.InstanceID)
+	serviceID := strings.TrimSpace(request.ServiceID)
+	method := strings.TrimSpace(request.Method)
+	switch {
+	case capsetID == "":
+		return "", "", "", "", nil, fmt.Errorf("%w: capset_id is required", ErrInvalidInvoke)
+	case instanceID == "":
+		return "", "", "", "", nil, fmt.Errorf("%w: instance_id is required", ErrInvalidInvoke)
+	case serviceID == "":
+		return "", "", "", "", nil, fmt.Errorf("%w: service_id is required", ErrInvalidInvoke)
+	case method == "":
+		return "", "", "", "", nil, fmt.Errorf("%w: method is required", ErrInvalidInvoke)
+	}
+	payload := json.RawMessage(request.Payload)
+	if len(payload) == 0 {
+		payload = json.RawMessage(`{}`)
+	}
+	if !json.Valid(payload) {
+		return "", "", "", "", nil, fmt.Errorf("%w: payload_json is invalid", ErrInvalidInvoke)
+	}
+	return capsetID, instanceID, serviceID, method, payload, nil
+}
+
 func (c *Client) getJSON(ctx context.Context, path string, target any) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.addr+path, nil)
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Accept", "application/json")
-	if c.token != "" {
-		req.Header.Set("Authorization", "Bearer "+c.token)
+	if token := c.adminAuthorizationToken(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -143,7 +208,15 @@ func (c *Client) getJSON(ctx context.Context, path string, target any) error {
 	return nil
 }
 
+func (c *Client) adminAuthorizationToken() string {
+	if c.adminToken != "" {
+		return c.adminToken
+	}
+	return c.token
+}
+
 var (
 	ErrNotConfigured  = errors.New("octobus is not configured")
 	ErrInvalidCatalog = errors.New("invalid capability catalog")
+	ErrInvalidInvoke  = errors.New("invalid capability invoke")
 )

--- a/pkg/capability/client_test.go
+++ b/pkg/capability/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -143,6 +144,137 @@ func TestClientCatalogMarkdownPreservesPlainTextOctoBusError(t *testing.T) {
 	}
 	if upstream.HTTPStatus != http.StatusServiceUnavailable || upstream.Code != "HTTP_503" || upstream.Message != http.StatusText(http.StatusServiceUnavailable) {
 		t.Fatalf("unexpected OctoBus error fallback: %+v", upstream)
+	}
+}
+
+func TestClientInvokeConnectPostsJSONAndPreservesResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.EscapedPath() != "/capsets/threat-intel/connect/cloud/ThreatBook.Cloud/IpReputation" {
+			t.Fatalf("unexpected path %s", r.URL.EscapedPath())
+		}
+		if r.Header.Get("Authorization") != "Bearer secret-token" {
+			t.Fatalf("unexpected authorization header %q", r.Header.Get("Authorization"))
+		}
+		if r.Header.Get("Connect-Protocol-Version") != "1" {
+			t.Fatalf("unexpected connect protocol header %q", r.Header.Get("Connect-Protocol-Version"))
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(body) != `{"resource":"8.8.8.8","lang":"zh"}` {
+			t.Fatalf("unexpected body %s", body)
+		}
+		_, _ = w.Write([]byte(`{"response_code":0,"data":{"is_malicious":false}}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Addr: server.URL, Token: "secret-token"})
+	result, err := client.InvokeConnect(context.Background(), InvokeRequest{
+		CapsetID:   "threat-intel",
+		InstanceID: "cloud",
+		ServiceID:  "ThreatBook.Cloud",
+		Method:     "IpReputation",
+		Payload:    json.RawMessage(`{"resource":"8.8.8.8","lang":"zh"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(result) != `{"response_code":0,"data":{"is_malicious":false}}` {
+		t.Fatalf("unexpected result %s", result)
+	}
+}
+
+func TestClientSeparatesAdminAndInvokeTokens(t *testing.T) {
+	var adminAuthorization, invokeAuthorization string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/admin/v1/capsets":
+			adminAuthorization = r.Header.Get("Authorization")
+			_ = json.NewEncoder(w).Encode(map[string]any{"capsets": []any{}})
+		case "/capsets/threat-intel/connect/cloud/ThreatBook.Cloud/IpReputation":
+			invokeAuthorization = r.Header.Get("Authorization")
+			_, _ = w.Write([]byte(`{"response_code":0}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{
+		Addr:       server.URL,
+		Token:      "capset-token",
+		AdminToken: "admin-token",
+	})
+	if _, err := client.ListCapsets(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.InvokeConnect(context.Background(), InvokeRequest{
+		CapsetID:   "threat-intel",
+		InstanceID: "cloud",
+		ServiceID:  "ThreatBook.Cloud",
+		Method:     "IpReputation",
+		Payload:    json.RawMessage(`{"resource":"8.8.8.8"}`),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if adminAuthorization != "Bearer admin-token" {
+		t.Fatalf("admin authorization = %q", adminAuthorization)
+	}
+	if invokeAuthorization != "Bearer capset-token" {
+		t.Fatalf("invoke authorization = %q", invokeAuthorization)
+	}
+}
+
+func TestClientInvokeConnectPreservesConnectError(t *testing.T) {
+	const nestedMessage = `{"code":"FAILED_PRECONDITION","message":"threatbook upstream business failure","response_code":-4,"verbose_msg":"超出每月访问限制"}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusPreconditionFailed)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"code":    "failed_precondition",
+			"message": nestedMessage,
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{Addr: server.URL, Token: "capset-token"})
+	_, err := client.InvokeConnect(context.Background(), InvokeRequest{
+		CapsetID:   "threat-intel",
+		InstanceID: "cloud",
+		ServiceID:  "ThreatBook.Cloud",
+		Method:     "IpReputation",
+	})
+	if err == nil {
+		t.Fatal("InvokeConnect returned nil error")
+	}
+	var upstream *OctoBusError
+	if !errors.As(err, &upstream) {
+		t.Fatalf("InvokeConnect error type = %T, want *OctoBusError: %v", err, err)
+	}
+	if upstream.HTTPStatus != http.StatusPreconditionFailed || upstream.Code != "failed_precondition" || upstream.Message != nestedMessage {
+		t.Fatalf("unexpected OctoBus error: %+v", upstream)
+	}
+	if !strings.Contains(err.Error(), "response_code") || !strings.Contains(err.Error(), "超出每月访问限制") {
+		t.Fatalf("error string did not preserve upstream details: %v", err)
+	}
+}
+
+func TestClientInvokeConnectRejectsInvalidRequest(t *testing.T) {
+	client := NewClient(Config{Addr: "http://127.0.0.1:9000"})
+	tests := []InvokeRequest{
+		{InstanceID: "cloud", ServiceID: "svc", Method: "method"},
+		{CapsetID: "dev", ServiceID: "svc", Method: "method"},
+		{CapsetID: "dev", InstanceID: "cloud", Method: "method"},
+		{CapsetID: "dev", InstanceID: "cloud", ServiceID: "svc"},
+		{CapsetID: "dev", InstanceID: "cloud", ServiceID: "svc", Method: "method", Payload: json.RawMessage(`{`)},
+	}
+	for _, request := range tests {
+		if _, err := client.InvokeConnect(context.Background(), request); !errors.Is(err, ErrInvalidInvoke) {
+			t.Fatalf("InvokeConnect(%+v) error = %v, want ErrInvalidInvoke", request, err)
+		}
 	}
 }
 

--- a/pkg/capability/error.go
+++ b/pkg/capability/error.go
@@ -41,16 +41,31 @@ func octobusHTTPError(status int, body []byte) error {
 			Message string          `json:"message"`
 			Details json.RawMessage `json:"details"`
 		} `json:"error"`
+		Code    string          `json:"code"`
+		Message string          `json:"message"`
+		Details json.RawMessage `json:"details"`
 	}
 	if err := json.Unmarshal(body, &payload); err == nil {
-		if code := strings.TrimSpace(payload.Error.Code); code != "" {
+		code := strings.TrimSpace(payload.Error.Code)
+		if code == "" {
+			code = strings.TrimSpace(payload.Code)
+		}
+		if code != "" {
 			upstream.Code = code
 		}
-		if message := strings.TrimSpace(payload.Error.Message); message != "" {
+		message := strings.TrimSpace(payload.Error.Message)
+		if message == "" {
+			message = strings.TrimSpace(payload.Message)
+		}
+		if message != "" {
 			upstream.Message = message
 		}
-		if len(payload.Error.Details) > 0 {
-			upstream.Details = append(json.RawMessage(nil), payload.Error.Details...)
+		details := payload.Error.Details
+		if len(details) == 0 {
+			details = payload.Details
+		}
+		if len(details) > 0 {
+			upstream.Details = append(json.RawMessage(nil), details...)
 		}
 	}
 	return upstream

--- a/pkg/capability/types.go
+++ b/pkg/capability/types.go
@@ -1,6 +1,9 @@
 package capability
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 const (
 	ProtocolGRPC    = "grpc"
@@ -9,9 +12,18 @@ const (
 )
 
 type Config struct {
-	Addr    string
-	Token   string
-	Timeout time.Duration
+	Addr       string
+	Token      string
+	AdminToken string
+	Timeout    time.Duration
+}
+
+type InvokeRequest struct {
+	CapsetID   string
+	InstanceID string
+	ServiceID  string
+	Method     string
+	Payload    json.RawMessage
 }
 
 type Status struct {

--- a/pkg/llms/facade_bridge.go
+++ b/pkg/llms/facade_bridge.go
@@ -244,6 +244,9 @@ func RuntimeStreamBridge(inboundProtocol, upstreamProtocol protocolbridge.Protoc
 		if err != nil {
 			return nil, nil, err
 		}
+		if requiresCompletedChatToolCalls(inboundProtocol, upstreamProtocol) {
+			decoder = newCompletedToolCallStreamDecoder(decoder)
+		}
 		encoder, err := inboundAdapter.NewStreamEncoder(protocolbridge.StreamEncodeOptions{Model: model})
 		if err != nil {
 			return nil, nil, err
@@ -258,9 +261,170 @@ func RuntimeStreamBridge(inboundProtocol, upstreamProtocol protocolbridge.Protoc
 	if err != nil {
 		return nil, nil, err
 	}
+	if requiresCompletedChatToolCalls(inboundProtocol, upstreamProtocol) {
+		decoder = newCompletedToolCallStreamDecoder(decoder)
+	}
 	encoder, err := bridge.NewStreamEncoder(protocolbridge.StreamEncodeOptions{Model: model})
 	if err != nil {
 		return nil, nil, err
 	}
 	return decoder, encoder, nil
+}
+
+func requiresCompletedChatToolCalls(inboundProtocol, upstreamProtocol protocolbridge.Protocol) bool {
+	return inboundProtocol == protocolbridge.ProtocolOpenAIResponses && upstreamProtocol == protocolbridge.ProtocolOpenAIChat
+}
+
+// completedToolCallStreamDecoder buffers Chat tool-call fragments until the
+// stream finishes. The Responses encoder needs a complete tool call to emit
+// both function_call_arguments.done and output_item.done; Chat streams only
+// provide finish_reason=tool_calls and do not send a separate tool-input-end
+// event.
+type completedToolCallStreamDecoder struct {
+	inner   protocolbridge.StreamDecoder
+	order   []string
+	pending map[string]*completedToolCall
+}
+
+type completedToolCall struct {
+	id         string
+	toolCallID string
+	toolName   string
+	arguments  strings.Builder
+}
+
+func newCompletedToolCallStreamDecoder(inner protocolbridge.StreamDecoder) protocolbridge.StreamDecoder {
+	return &completedToolCallStreamDecoder{
+		inner:   inner,
+		pending: map[string]*completedToolCall{},
+	}
+}
+
+func (d *completedToolCallStreamDecoder) Decode(event protocolbridge.RawStreamEvent) ([]protocolbridge.StreamPart, error) {
+	parts, err := d.inner.Decode(event)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]protocolbridge.StreamPart, 0, len(parts)+1)
+	for _, part := range parts {
+		switch part.Type {
+		case protocolbridge.StreamToolInputStart:
+			d.start(part)
+		case protocolbridge.StreamToolInputDelta:
+			d.delta(part)
+		case protocolbridge.StreamToolInputEnd:
+			if toolCall := d.take(toolCallKey(part)); toolCall != nil {
+				out = append(out, d.completedPart(toolCall))
+			}
+		case protocolbridge.StreamFinish:
+			out = append(out, d.flush()...)
+			out = append(out, part)
+		default:
+			out = append(out, part)
+		}
+	}
+	return out, nil
+}
+
+func (d *completedToolCallStreamDecoder) Close() ([]protocolbridge.StreamPart, error) {
+	parts, err := d.inner.Close()
+	if err != nil {
+		return nil, err
+	}
+	out := d.flush()
+	out = append(out, parts...)
+	return out, nil
+}
+
+func (d *completedToolCallStreamDecoder) start(part protocolbridge.StreamPart) {
+	key := toolCallKey(part)
+	if key == "" {
+		return
+	}
+	toolCall, ok := d.pending[key]
+	if !ok {
+		toolCall = &completedToolCall{}
+		d.pending[key] = toolCall
+		d.order = append(d.order, key)
+	}
+	toolCall.id = firstNonEmptyString(part.ID, toolCall.id)
+	toolCall.toolCallID = firstNonEmptyString(part.ToolCallID, toolCall.toolCallID)
+	toolCall.toolName = firstNonEmptyString(part.ToolName, toolCall.toolName)
+}
+
+func (d *completedToolCallStreamDecoder) delta(part protocolbridge.StreamPart) {
+	key := toolCallKey(part)
+	if key == "" {
+		return
+	}
+	toolCall, ok := d.pending[key]
+	if !ok {
+		toolCall = &completedToolCall{}
+		d.pending[key] = toolCall
+		d.order = append(d.order, key)
+	}
+	toolCall.id = firstNonEmptyString(part.ID, toolCall.id)
+	toolCall.toolCallID = firstNonEmptyString(part.ToolCallID, toolCall.toolCallID)
+	toolCall.toolName = firstNonEmptyString(part.ToolName, toolCall.toolName)
+	toolCall.arguments.WriteString(part.Delta)
+}
+
+func (d *completedToolCallStreamDecoder) take(key string) *completedToolCall {
+	if key == "" {
+		return nil
+	}
+	toolCall := d.pending[key]
+	if toolCall == nil {
+		return nil
+	}
+	delete(d.pending, key)
+	for index, current := range d.order {
+		if current == key {
+			d.order = append(d.order[:index], d.order[index+1:]...)
+			break
+		}
+	}
+	return toolCall
+}
+
+func (d *completedToolCallStreamDecoder) flush() []protocolbridge.StreamPart {
+	parts := make([]protocolbridge.StreamPart, 0, len(d.order))
+	for _, key := range d.order {
+		if toolCall := d.pending[key]; toolCall != nil {
+			parts = append(parts, d.completedPart(toolCall))
+		}
+	}
+	d.order = nil
+	d.pending = map[string]*completedToolCall{}
+	return parts
+}
+
+func (d *completedToolCallStreamDecoder) completedPart(toolCall *completedToolCall) protocolbridge.StreamPart {
+	arguments := toolCall.arguments.String()
+	var input any
+	if strings.TrimSpace(arguments) == "" {
+		input = map[string]any{}
+	} else if err := json.Unmarshal([]byte(arguments), &input); err != nil {
+		input = map[string]any{"_raw": arguments}
+	}
+	return protocolbridge.StreamPart{
+		Type:       protocolbridge.StreamToolCall,
+		ID:         toolCall.id,
+		ToolCallID: toolCall.toolCallID,
+		ToolName:   toolCall.toolName,
+		Input:      input,
+	}
+}
+
+func toolCallKey(part protocolbridge.StreamPart) string {
+	return firstNonEmptyString(part.ID, part.ToolCallID)
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/pkg/llms/facade_bridge_test.go
+++ b/pkg/llms/facade_bridge_test.go
@@ -2,10 +2,80 @@ package llms
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	protocolbridge "github.com/chaitin/ai-api-protocol-bridge"
 )
+
+func TestRuntimeStreamBridgeCompletesChatToolCallForResponses(t *testing.T) {
+	decoder, encoder, err := RuntimeStreamBridge(
+		protocolbridge.ProtocolOpenAIResponses,
+		protocolbridge.ProtocolOpenAIChat,
+		ProviderFamilyOpenAI,
+		"deepseek-chat",
+	)
+	if err != nil {
+		t.Fatalf("RuntimeStreamBridge() error = %v", err)
+	}
+
+	chunks := []string{
+		`{"id":"chatcmpl-1","object":"chat.completion.chunk","created":0,"model":"deepseek-chat","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"exec_command","arguments":""}}]},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-1","object":"chat.completion.chunk","created":0,"model":"deepseek-chat","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"cmd\":\"echo bridge"}}]},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-1","object":"chat.completion.chunk","created":0,"model":"deepseek-chat","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-response-canary\"}"}}]},"finish_reason":null}]}`,
+		`{"id":"chatcmpl-1","object":"chat.completion.chunk","created":0,"model":"deepseek-chat","choices":[{"index":0,"delta":{"content":""},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+	}
+
+	var encoded []protocolbridge.RawStreamEvent
+	for _, chunk := range chunks {
+		parts, decodeErr := decoder.Decode(protocolbridge.RawStreamEvent{Data: []byte(chunk)})
+		if decodeErr != nil {
+			t.Fatalf("Decode() error = %v", decodeErr)
+		}
+		for _, part := range parts {
+			events, encodeErr := encoder.Encode(part)
+			if encodeErr != nil {
+				t.Fatalf("Encode(%s) error = %v", part.Type, encodeErr)
+			}
+			encoded = append(encoded, events...)
+		}
+	}
+	parts, err := decoder.Close()
+	if err != nil {
+		t.Fatalf("decoder.Close() error = %v", err)
+	}
+	for _, part := range parts {
+		events, encodeErr := encoder.Encode(part)
+		if encodeErr != nil {
+			t.Fatalf("Encode(%s) after close error = %v", part.Type, encodeErr)
+		}
+		encoded = append(encoded, events...)
+	}
+	events, err := encoder.Close()
+	if err != nil {
+		t.Fatalf("encoder.Close() error = %v", err)
+	}
+	encoded = append(encoded, events...)
+
+	var body strings.Builder
+	for _, event := range encoded {
+		body.Write(event.Data)
+		body.WriteByte('\n')
+	}
+	got := body.String()
+	for _, want := range []string{
+		`"type":"response.output_item.added"`,
+		`"type":"response.function_call_arguments.delta"`,
+		`"type":"response.function_call_arguments.done"`,
+		`"type":"response.output_item.done"`,
+		`"type":"response.completed"`,
+		`"arguments":"{\"cmd\":\"echo bridge-response-canary\"}"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("encoded stream missing %s:\n%s", want, got)
+		}
+	}
+}
 
 func TestRewriteRuntimeRequestForUpstreamPreservesAssistantTextAfterToolCall(t *testing.T) {
 	body := []byte(`{

--- a/pkg/model/capability_model.go
+++ b/pkg/model/capability_model.go
@@ -5,6 +5,7 @@ package model
 // dynamically at request time. The deployment-fixed proxy listen/target
 // addresses are intentionally not stored here.
 type CapabilityGatewaySettings struct {
-	Addr  string
-	Token string
+	Addr       string
+	Token      string
+	AdminToken string
 }

--- a/pkg/runs/capability_guide_routing_test.go
+++ b/pkg/runs/capability_guide_routing_test.go
@@ -2,6 +2,7 @@ package runs
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -30,6 +31,9 @@ func (scopedRunGuideProvider) Catalog(context.Context, string) (capability.Catal
 func (scopedRunGuideProvider) ProxyTarget() string { return "proxy:1" }
 func (scopedRunGuideProvider) CapabilityGuide(_ context.Context, id string) ([]byte, error) {
 	return []byte("global " + id), nil
+}
+func (scopedRunGuideProvider) InvokeConnect(context.Context, capability.InvokeRequest) (json.RawMessage, error) {
+	return nil, capability.ErrNotConfigured
 }
 func (p *scopedRunGuideProvider) CapabilityGuideForScope(_ context.Context, scope capabilities.GuideScope, declaration string) ([]byte, error) {
 	p.scope = scope

--- a/pkg/runs/coverage_shape_workflows_test.go
+++ b/pkg/runs/coverage_shape_workflows_test.go
@@ -3172,6 +3172,10 @@ func (p fakeCapabilityProvider) CapabilityGuide(_ context.Context, capsetID stri
 	return nil, errors.New("not found")
 }
 
+func (p fakeCapabilityProvider) InvokeConnect(context.Context, capability.InvokeRequest) (json.RawMessage, error) {
+	return nil, capability.ErrNotConfigured
+}
+
 func (p fakeCapabilityProvider) ProxyTarget() string {
 	return p.target
 }

--- a/pkg/storage/configstore/capability_gateway_store.go
+++ b/pkg/storage/configstore/capability_gateway_store.go
@@ -22,9 +22,9 @@ const capabilityGatewayRowID = 1
 // GetCapabilityGateway returns the stored OctoBus connection. An empty addr
 // means the gateway is not configured.
 func (s *capabilityGatewayStore) GetCapabilityGateway(ctx context.Context) (domain.CapabilityGatewaySettings, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT addr, token FROM capability_gateway WHERE id = ?`, capabilityGatewayRowID)
+	row := s.db.QueryRowContext(ctx, `SELECT addr, token, admin_token FROM capability_gateway WHERE id = ?`, capabilityGatewayRowID)
 	var settings domain.CapabilityGatewaySettings
-	switch err := row.Scan(&settings.Addr, &settings.Token); {
+	switch err := row.Scan(&settings.Addr, &settings.Token, &settings.AdminToken); {
 	case errors.Is(err, sql.ErrNoRows):
 		return domain.CapabilityGatewaySettings{}, nil
 	case err != nil:
@@ -37,10 +37,11 @@ func (s *capabilityGatewayStore) GetCapabilityGateway(ctx context.Context) (doma
 func (s *capabilityGatewayStore) SaveCapabilityGateway(ctx context.Context, settings domain.CapabilityGatewaySettings) (domain.CapabilityGatewaySettings, error) {
 	settings.Addr = strings.TrimSpace(settings.Addr)
 	settings.Token = strings.TrimSpace(settings.Token)
+	settings.AdminToken = strings.TrimSpace(settings.AdminToken)
 	if _, err := s.db.ExecContext(ctx,
-		`INSERT INTO capability_gateway(id, addr, token, updated_at) VALUES(?, ?, ?, ?)
-		 ON CONFLICT(id) DO UPDATE SET addr = excluded.addr, token = excluded.token, updated_at = excluded.updated_at`,
-		capabilityGatewayRowID, settings.Addr, settings.Token, time.Now().UTC().Unix()); err != nil {
+		`INSERT INTO capability_gateway(id, addr, token, admin_token, updated_at) VALUES(?, ?, ?, ?, ?)
+		 ON CONFLICT(id) DO UPDATE SET addr = excluded.addr, token = excluded.token, admin_token = excluded.admin_token, updated_at = excluded.updated_at`,
+		capabilityGatewayRowID, settings.Addr, settings.Token, settings.AdminToken, time.Now().UTC().Unix()); err != nil {
 		return domain.CapabilityGatewaySettings{}, fmt.Errorf("save capability gateway: %w", err)
 	}
 	return settings, nil

--- a/pkg/storage/configstore/schema_coverage_test.go
+++ b/pkg/storage/configstore/schema_coverage_test.go
@@ -486,11 +486,16 @@ func testConfigStoreCRUDCoverageWorkflows(t *testing.T) {
 	if err := store.InitSchema(ctx); err != nil {
 		t.Fatalf("second InitSchema returned error: %v", err)
 	}
+	assertTableColumns(t, store, "capability_gateway", "addr", "token", "admin_token")
 
-	if saved, err := store.SaveCapabilityGateway(ctx, domain.CapabilityGatewaySettings{Addr: "http://octobus", Token: "token"}); err != nil || saved.Addr == "" {
+	if saved, err := store.SaveCapabilityGateway(ctx, domain.CapabilityGatewaySettings{
+		Addr:       "http://octobus",
+		Token:      "capset-token",
+		AdminToken: "admin-token",
+	}); err != nil || saved.Addr == "" {
 		t.Fatalf("SaveCapabilityGateway saved=%#v err=%v", saved, err)
 	}
-	if gateway, err := store.GetCapabilityGateway(ctx); err != nil || gateway.Token != "token" {
+	if gateway, err := store.GetCapabilityGateway(ctx); err != nil || gateway.Token != "capset-token" || gateway.AdminToken != "admin-token" {
 		t.Fatalf("GetCapabilityGateway gateway=%#v err=%v", gateway, err)
 	}
 

--- a/pkg/storage/sqlite/migrations/000015_capability_gateway_admin_token.sql
+++ b/pkg/storage/sqlite/migrations/000015_capability_gateway_admin_token.sql
@@ -1,0 +1,2 @@
+ALTER TABLE capability_gateway
+ADD COLUMN admin_token TEXT NOT NULL DEFAULT '';

--- a/pkg/storage/sqlite/v2_migration_design_test.go
+++ b/pkg/storage/sqlite/v2_migration_design_test.go
@@ -428,8 +428,8 @@ func loadV2MigrationDesignChain(t *testing.T) []migration {
 	if err != nil {
 		t.Fatalf("load migrations: %v", err)
 	}
-	if len(chain) != 14 {
-		t.Fatalf("migration count = %d, want 14", len(chain))
+	if len(chain) != 15 {
+		t.Fatalf("migration count = %d, want 15", len(chain))
 	}
 	return chain
 }

--- a/proto/agentcompose/v2/agentcompose.pb.go
+++ b/proto/agentcompose/v2/agentcompose.pb.go
@@ -16629,9 +16629,12 @@ func (*GetCapabilityGatewayConfigRequest) Descriptor() ([]byte, []int) {
 }
 
 type CapabilityGatewayConfig struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Addr          string                 `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
-	TokenSet      bool                   `protobuf:"varint,2,opt,name=token_set,json=tokenSet,proto3" json:"token_set,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Addr  string                 `protobuf:"bytes,1,opt,name=addr,proto3" json:"addr,omitempty"`
+	// Whether the capset token used for business capability invocation is set.
+	TokenSet bool `protobuf:"varint,2,opt,name=token_set,json=tokenSet,proto3" json:"token_set,omitempty"`
+	// Whether the OctoBus admin token used for status/catalog access is set.
+	AdminTokenSet bool `protobuf:"varint,3,opt,name=admin_token_set,json=adminTokenSet,proto3" json:"admin_token_set,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -16676,6 +16679,13 @@ func (x *CapabilityGatewayConfig) GetAddr() string {
 func (x *CapabilityGatewayConfig) GetTokenSet() bool {
 	if x != nil {
 		return x.TokenSet
+	}
+	return false
+}
+
+func (x *CapabilityGatewayConfig) GetAdminTokenSet() bool {
+	if x != nil {
+		return x.AdminTokenSet
 	}
 	return false
 }
@@ -16728,8 +16738,10 @@ type UpdateCapabilityGatewayConfigRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Field patch: absent is no-op; present empty explicitly clears the address.
 	Addr *string `protobuf:"bytes,1,opt,name=addr,proto3,oneof" json:"addr,omitempty"`
-	// Field patch: absent is no-op; present empty explicitly clears the token.
-	Token         *string `protobuf:"bytes,2,opt,name=token,proto3,oneof" json:"token,omitempty"`
+	// Field patch: absent is no-op; present empty explicitly clears the capset token.
+	Token *string `protobuf:"bytes,2,opt,name=token,proto3,oneof" json:"token,omitempty"`
+	// Field patch: absent is no-op; present empty explicitly clears the admin token.
+	AdminToken    *string `protobuf:"bytes,3,opt,name=admin_token,json=adminToken,proto3,oneof" json:"admin_token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -16774,6 +16786,13 @@ func (x *UpdateCapabilityGatewayConfigRequest) GetAddr() string {
 func (x *UpdateCapabilityGatewayConfigRequest) GetToken() string {
 	if x != nil && x.Token != nil {
 		return *x.Token
+	}
+	return ""
+}
+
+func (x *UpdateCapabilityGatewayConfigRequest) GetAdminToken() string {
+	if x != nil && x.AdminToken != nil {
+		return *x.AdminToken
 	}
 	return ""
 }
@@ -17918,6 +17937,128 @@ func (x *GetCapabilityCatalogResponse) GetMethods() []*CapabilityMethod {
 	return nil
 }
 
+type InvokeCapabilityRequest struct {
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	CapsetId   string                 `protobuf:"bytes,1,opt,name=capset_id,json=capsetId,proto3" json:"capset_id,omitempty"`
+	InstanceId string                 `protobuf:"bytes,2,opt,name=instance_id,json=instanceId,proto3" json:"instance_id,omitempty"`
+	ServiceId  string                 `protobuf:"bytes,3,opt,name=service_id,json=serviceId,proto3" json:"service_id,omitempty"`
+	Method     string                 `protobuf:"bytes,4,opt,name=method,proto3" json:"method,omitempty"`
+	// JSON-encoded request object forwarded to the OctoBus Connect RPC method.
+	PayloadJson   string `protobuf:"bytes,5,opt,name=payload_json,json=payloadJson,proto3" json:"payload_json,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InvokeCapabilityRequest) Reset() {
+	*x = InvokeCapabilityRequest{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[218]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InvokeCapabilityRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InvokeCapabilityRequest) ProtoMessage() {}
+
+func (x *InvokeCapabilityRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[218]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InvokeCapabilityRequest.ProtoReflect.Descriptor instead.
+func (*InvokeCapabilityRequest) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{218}
+}
+
+func (x *InvokeCapabilityRequest) GetCapsetId() string {
+	if x != nil {
+		return x.CapsetId
+	}
+	return ""
+}
+
+func (x *InvokeCapabilityRequest) GetInstanceId() string {
+	if x != nil {
+		return x.InstanceId
+	}
+	return ""
+}
+
+func (x *InvokeCapabilityRequest) GetServiceId() string {
+	if x != nil {
+		return x.ServiceId
+	}
+	return ""
+}
+
+func (x *InvokeCapabilityRequest) GetMethod() string {
+	if x != nil {
+		return x.Method
+	}
+	return ""
+}
+
+func (x *InvokeCapabilityRequest) GetPayloadJson() string {
+	if x != nil {
+		return x.PayloadJson
+	}
+	return ""
+}
+
+type InvokeCapabilityResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// JSON-encoded response object returned by the OctoBus Connect RPC method.
+	ResultJson    string `protobuf:"bytes,1,opt,name=result_json,json=resultJson,proto3" json:"result_json,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InvokeCapabilityResponse) Reset() {
+	*x = InvokeCapabilityResponse{}
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[219]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InvokeCapabilityResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InvokeCapabilityResponse) ProtoMessage() {}
+
+func (x *InvokeCapabilityResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[219]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InvokeCapabilityResponse.ProtoReflect.Descriptor instead.
+func (*InvokeCapabilityResponse) Descriptor() ([]byte, []int) {
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{219}
+}
+
+func (x *InvokeCapabilityResponse) GetResultJson() string {
+	if x != nil {
+		return x.ResultJson
+	}
+	return ""
+}
+
 type ListSandboxHistoryRequest struct {
 	state     protoimpl.MessageState `protogen:"open.v1"`
 	SandboxId string                 `protobuf:"bytes,1,opt,name=sandbox_id,json=sandboxId,proto3" json:"sandbox_id,omitempty"`
@@ -17931,7 +18072,7 @@ type ListSandboxHistoryRequest struct {
 
 func (x *ListSandboxHistoryRequest) Reset() {
 	*x = ListSandboxHistoryRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[218]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[220]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -17943,7 +18084,7 @@ func (x *ListSandboxHistoryRequest) String() string {
 func (*ListSandboxHistoryRequest) ProtoMessage() {}
 
 func (x *ListSandboxHistoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[218]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[220]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -17956,7 +18097,7 @@ func (x *ListSandboxHistoryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxHistoryRequest.ProtoReflect.Descriptor instead.
 func (*ListSandboxHistoryRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{218}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{220}
 }
 
 func (x *ListSandboxHistoryRequest) GetSandboxId() string {
@@ -18001,7 +18142,7 @@ type SandboxHistoryCell struct {
 
 func (x *SandboxHistoryCell) Reset() {
 	*x = SandboxHistoryCell{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[219]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[221]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -18013,7 +18154,7 @@ func (x *SandboxHistoryCell) String() string {
 func (*SandboxHistoryCell) ProtoMessage() {}
 
 func (x *SandboxHistoryCell) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[219]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[221]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -18026,7 +18167,7 @@ func (x *SandboxHistoryCell) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxHistoryCell.ProtoReflect.Descriptor instead.
 func (*SandboxHistoryCell) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{219}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{221}
 }
 
 func (x *SandboxHistoryCell) GetId() string {
@@ -18133,7 +18274,7 @@ type SandboxHistoryEvent struct {
 
 func (x *SandboxHistoryEvent) Reset() {
 	*x = SandboxHistoryEvent{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[220]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[222]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -18145,7 +18286,7 @@ func (x *SandboxHistoryEvent) String() string {
 func (*SandboxHistoryEvent) ProtoMessage() {}
 
 func (x *SandboxHistoryEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[220]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[222]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -18158,7 +18299,7 @@ func (x *SandboxHistoryEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxHistoryEvent.ProtoReflect.Descriptor instead.
 func (*SandboxHistoryEvent) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{220}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{222}
 }
 
 func (x *SandboxHistoryEvent) GetId() string {
@@ -18209,7 +18350,7 @@ type ListSandboxHistoryResponse struct {
 
 func (x *ListSandboxHistoryResponse) Reset() {
 	*x = ListSandboxHistoryResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[221]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[223]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -18221,7 +18362,7 @@ func (x *ListSandboxHistoryResponse) String() string {
 func (*ListSandboxHistoryResponse) ProtoMessage() {}
 
 func (x *ListSandboxHistoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[221]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[223]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -18234,7 +18375,7 @@ func (x *ListSandboxHistoryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSandboxHistoryResponse.ProtoReflect.Descriptor instead.
 func (*ListSandboxHistoryResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{221}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{223}
 }
 
 func (x *ListSandboxHistoryResponse) GetCells() []*SandboxHistoryCell {
@@ -18274,7 +18415,7 @@ type WatchSandboxRequest struct {
 
 func (x *WatchSandboxRequest) Reset() {
 	*x = WatchSandboxRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[222]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[224]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -18286,7 +18427,7 @@ func (x *WatchSandboxRequest) String() string {
 func (*WatchSandboxRequest) ProtoMessage() {}
 
 func (x *WatchSandboxRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[222]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[224]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -18299,7 +18440,7 @@ func (x *WatchSandboxRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchSandboxRequest.ProtoReflect.Descriptor instead.
 func (*WatchSandboxRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{222}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{224}
 }
 
 func (x *WatchSandboxRequest) GetSandboxId() string {
@@ -18324,7 +18465,7 @@ type WatchSandboxResponse struct {
 
 func (x *WatchSandboxResponse) Reset() {
 	*x = WatchSandboxResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[223]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[225]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -18336,7 +18477,7 @@ func (x *WatchSandboxResponse) String() string {
 func (*WatchSandboxResponse) ProtoMessage() {}
 
 func (x *WatchSandboxResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[223]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[225]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -18349,7 +18490,7 @@ func (x *WatchSandboxResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchSandboxResponse.ProtoReflect.Descriptor instead.
 func (*WatchSandboxResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{223}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{225}
 }
 
 func (x *WatchSandboxResponse) GetEventType() SandboxWatchEventType {
@@ -18412,7 +18553,7 @@ type GenerateLLMRequest struct {
 
 func (x *GenerateLLMRequest) Reset() {
 	*x = GenerateLLMRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[224]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[226]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -18424,7 +18565,7 @@ func (x *GenerateLLMRequest) String() string {
 func (*GenerateLLMRequest) ProtoMessage() {}
 
 func (x *GenerateLLMRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[224]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[226]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -18437,7 +18578,7 @@ func (x *GenerateLLMRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateLLMRequest.ProtoReflect.Descriptor instead.
 func (*GenerateLLMRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{224}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{226}
 }
 
 func (x *GenerateLLMRequest) GetPrompt() string {
@@ -18474,7 +18615,7 @@ type GenerateLLMResponse struct {
 
 func (x *GenerateLLMResponse) Reset() {
 	*x = GenerateLLMResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[225]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[227]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -18486,7 +18627,7 @@ func (x *GenerateLLMResponse) String() string {
 func (*GenerateLLMResponse) ProtoMessage() {}
 
 func (x *GenerateLLMResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[225]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[227]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -18499,7 +18640,7 @@ func (x *GenerateLLMResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateLLMResponse.ProtoReflect.Descriptor instead.
 func (*GenerateLLMResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{225}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{227}
 }
 
 func (x *GenerateLLMResponse) GetText() string {
@@ -18554,7 +18695,7 @@ type StreamProjectSchedulerEventsRequest struct {
 
 func (x *StreamProjectSchedulerEventsRequest) Reset() {
 	*x = StreamProjectSchedulerEventsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[226]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[228]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -18566,7 +18707,7 @@ func (x *StreamProjectSchedulerEventsRequest) String() string {
 func (*StreamProjectSchedulerEventsRequest) ProtoMessage() {}
 
 func (x *StreamProjectSchedulerEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[226]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[228]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -18579,7 +18720,7 @@ func (x *StreamProjectSchedulerEventsRequest) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use StreamProjectSchedulerEventsRequest.ProtoReflect.Descriptor instead.
 func (*StreamProjectSchedulerEventsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{226}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{228}
 }
 
 func (x *StreamProjectSchedulerEventsRequest) GetProject() *ProjectRef {
@@ -18636,7 +18777,7 @@ type StreamProjectSchedulerEventsResponse struct {
 
 func (x *StreamProjectSchedulerEventsResponse) Reset() {
 	*x = StreamProjectSchedulerEventsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[227]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[229]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -18648,7 +18789,7 @@ func (x *StreamProjectSchedulerEventsResponse) String() string {
 func (*StreamProjectSchedulerEventsResponse) ProtoMessage() {}
 
 func (x *StreamProjectSchedulerEventsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[227]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[229]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -18661,7 +18802,7 @@ func (x *StreamProjectSchedulerEventsResponse) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use StreamProjectSchedulerEventsResponse.ProtoReflect.Descriptor instead.
 func (*StreamProjectSchedulerEventsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{227}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{229}
 }
 
 func (x *StreamProjectSchedulerEventsResponse) GetEvents() []*SchedulerEvent {
@@ -18708,7 +18849,7 @@ type StreamSchedulerRunsRequest struct {
 
 func (x *StreamSchedulerRunsRequest) Reset() {
 	*x = StreamSchedulerRunsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[228]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[230]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -18720,7 +18861,7 @@ func (x *StreamSchedulerRunsRequest) String() string {
 func (*StreamSchedulerRunsRequest) ProtoMessage() {}
 
 func (x *StreamSchedulerRunsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[228]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[230]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -18733,7 +18874,7 @@ func (x *StreamSchedulerRunsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamSchedulerRunsRequest.ProtoReflect.Descriptor instead.
 func (*StreamSchedulerRunsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{228}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{230}
 }
 
 func (x *StreamSchedulerRunsRequest) GetProject() *ProjectRef {
@@ -18791,7 +18932,7 @@ type StreamSchedulerRunsResponse struct {
 
 func (x *StreamSchedulerRunsResponse) Reset() {
 	*x = StreamSchedulerRunsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[229]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[231]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -18803,7 +18944,7 @@ func (x *StreamSchedulerRunsResponse) String() string {
 func (*StreamSchedulerRunsResponse) ProtoMessage() {}
 
 func (x *StreamSchedulerRunsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[229]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[231]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -18816,7 +18957,7 @@ func (x *StreamSchedulerRunsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StreamSchedulerRunsResponse.ProtoReflect.Descriptor instead.
 func (*StreamSchedulerRunsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{229}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{231}
 }
 
 func (x *StreamSchedulerRunsResponse) GetRuns() []*SchedulerRun {
@@ -18866,7 +19007,7 @@ type BatchGetLatestSchedulerRunsRequest struct {
 
 func (x *BatchGetLatestSchedulerRunsRequest) Reset() {
 	*x = BatchGetLatestSchedulerRunsRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[230]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[232]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -18878,7 +19019,7 @@ func (x *BatchGetLatestSchedulerRunsRequest) String() string {
 func (*BatchGetLatestSchedulerRunsRequest) ProtoMessage() {}
 
 func (x *BatchGetLatestSchedulerRunsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[230]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[232]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -18891,7 +19032,7 @@ func (x *BatchGetLatestSchedulerRunsRequest) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use BatchGetLatestSchedulerRunsRequest.ProtoReflect.Descriptor instead.
 func (*BatchGetLatestSchedulerRunsRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{230}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{232}
 }
 
 func (x *BatchGetLatestSchedulerRunsRequest) GetProject() *ProjectRef {
@@ -18920,7 +19061,7 @@ type SandboxSchedulerRun struct {
 
 func (x *SandboxSchedulerRun) Reset() {
 	*x = SandboxSchedulerRun{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[231]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[233]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -18932,7 +19073,7 @@ func (x *SandboxSchedulerRun) String() string {
 func (*SandboxSchedulerRun) ProtoMessage() {}
 
 func (x *SandboxSchedulerRun) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[231]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[233]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -18945,7 +19086,7 @@ func (x *SandboxSchedulerRun) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SandboxSchedulerRun.ProtoReflect.Descriptor instead.
 func (*SandboxSchedulerRun) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{231}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{233}
 }
 
 func (x *SandboxSchedulerRun) GetSandboxId() string {
@@ -18973,7 +19114,7 @@ type BatchGetLatestSchedulerRunsResponse struct {
 
 func (x *BatchGetLatestSchedulerRunsResponse) Reset() {
 	*x = BatchGetLatestSchedulerRunsResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[232]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[234]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -18985,7 +19126,7 @@ func (x *BatchGetLatestSchedulerRunsResponse) String() string {
 func (*BatchGetLatestSchedulerRunsResponse) ProtoMessage() {}
 
 func (x *BatchGetLatestSchedulerRunsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[232]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[234]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -18998,7 +19139,7 @@ func (x *BatchGetLatestSchedulerRunsResponse) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use BatchGetLatestSchedulerRunsResponse.ProtoReflect.Descriptor instead.
 func (*BatchGetLatestSchedulerRunsResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{232}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{234}
 }
 
 func (x *BatchGetLatestSchedulerRunsResponse) GetResults() []*SandboxSchedulerRun {
@@ -19025,7 +19166,7 @@ type LLMProvider struct {
 
 func (x *LLMProvider) Reset() {
 	*x = LLMProvider{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[233]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[235]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -19037,7 +19178,7 @@ func (x *LLMProvider) String() string {
 func (*LLMProvider) ProtoMessage() {}
 
 func (x *LLMProvider) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[233]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[235]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -19050,7 +19191,7 @@ func (x *LLMProvider) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LLMProvider.ProtoReflect.Descriptor instead.
 func (*LLMProvider) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{233}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{235}
 }
 
 func (x *LLMProvider) GetId() string {
@@ -19128,7 +19269,7 @@ type LLMProviderSpec struct {
 
 func (x *LLMProviderSpec) Reset() {
 	*x = LLMProviderSpec{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[234]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[236]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -19140,7 +19281,7 @@ func (x *LLMProviderSpec) String() string {
 func (*LLMProviderSpec) ProtoMessage() {}
 
 func (x *LLMProviderSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[234]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[236]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -19153,7 +19294,7 @@ func (x *LLMProviderSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LLMProviderSpec.ProtoReflect.Descriptor instead.
 func (*LLMProviderSpec) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{234}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{236}
 }
 
 func (x *LLMProviderSpec) GetId() string {
@@ -19207,7 +19348,7 @@ type CreateProviderRequest struct {
 
 func (x *CreateProviderRequest) Reset() {
 	*x = CreateProviderRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[235]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[237]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -19219,7 +19360,7 @@ func (x *CreateProviderRequest) String() string {
 func (*CreateProviderRequest) ProtoMessage() {}
 
 func (x *CreateProviderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[235]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[237]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -19232,7 +19373,7 @@ func (x *CreateProviderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateProviderRequest.ProtoReflect.Descriptor instead.
 func (*CreateProviderRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{235}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{237}
 }
 
 func (x *CreateProviderRequest) GetProvider() *LLMProviderSpec {
@@ -19251,7 +19392,7 @@ type CreateProviderResponse struct {
 
 func (x *CreateProviderResponse) Reset() {
 	*x = CreateProviderResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[236]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[238]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -19263,7 +19404,7 @@ func (x *CreateProviderResponse) String() string {
 func (*CreateProviderResponse) ProtoMessage() {}
 
 func (x *CreateProviderResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[236]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[238]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -19276,7 +19417,7 @@ func (x *CreateProviderResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateProviderResponse.ProtoReflect.Descriptor instead.
 func (*CreateProviderResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{236}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{238}
 }
 
 func (x *CreateProviderResponse) GetProvider() *LLMProvider {
@@ -19295,7 +19436,7 @@ type GetProviderRequest struct {
 
 func (x *GetProviderRequest) Reset() {
 	*x = GetProviderRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[237]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[239]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -19307,7 +19448,7 @@ func (x *GetProviderRequest) String() string {
 func (*GetProviderRequest) ProtoMessage() {}
 
 func (x *GetProviderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[237]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[239]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -19320,7 +19461,7 @@ func (x *GetProviderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetProviderRequest.ProtoReflect.Descriptor instead.
 func (*GetProviderRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{237}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{239}
 }
 
 func (x *GetProviderRequest) GetId() string {
@@ -19339,7 +19480,7 @@ type GetProviderResponse struct {
 
 func (x *GetProviderResponse) Reset() {
 	*x = GetProviderResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[238]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[240]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -19351,7 +19492,7 @@ func (x *GetProviderResponse) String() string {
 func (*GetProviderResponse) ProtoMessage() {}
 
 func (x *GetProviderResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[238]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[240]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -19364,7 +19505,7 @@ func (x *GetProviderResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetProviderResponse.ProtoReflect.Descriptor instead.
 func (*GetProviderResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{238}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{240}
 }
 
 func (x *GetProviderResponse) GetProvider() *LLMProvider {
@@ -19385,7 +19526,7 @@ type ListProvidersRequest struct {
 
 func (x *ListProvidersRequest) Reset() {
 	*x = ListProvidersRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[239]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[241]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -19397,7 +19538,7 @@ func (x *ListProvidersRequest) String() string {
 func (*ListProvidersRequest) ProtoMessage() {}
 
 func (x *ListProvidersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[239]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[241]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -19410,7 +19551,7 @@ func (x *ListProvidersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListProvidersRequest.ProtoReflect.Descriptor instead.
 func (*ListProvidersRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{239}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{241}
 }
 
 func (x *ListProvidersRequest) GetOffset() uint32 {
@@ -19437,7 +19578,7 @@ type ListProvidersResponse struct {
 
 func (x *ListProvidersResponse) Reset() {
 	*x = ListProvidersResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[240]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[242]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -19449,7 +19590,7 @@ func (x *ListProvidersResponse) String() string {
 func (*ListProvidersResponse) ProtoMessage() {}
 
 func (x *ListProvidersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[240]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[242]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -19462,7 +19603,7 @@ func (x *ListProvidersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListProvidersResponse.ProtoReflect.Descriptor instead.
 func (*ListProvidersResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{240}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{242}
 }
 
 func (x *ListProvidersResponse) GetProviders() []*LLMProvider {
@@ -19488,7 +19629,7 @@ type UpdateProviderRequest struct {
 
 func (x *UpdateProviderRequest) Reset() {
 	*x = UpdateProviderRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[241]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[243]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -19500,7 +19641,7 @@ func (x *UpdateProviderRequest) String() string {
 func (*UpdateProviderRequest) ProtoMessage() {}
 
 func (x *UpdateProviderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[241]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[243]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -19513,7 +19654,7 @@ func (x *UpdateProviderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateProviderRequest.ProtoReflect.Descriptor instead.
 func (*UpdateProviderRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{241}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{243}
 }
 
 func (x *UpdateProviderRequest) GetProvider() *LLMProviderSpec {
@@ -19532,7 +19673,7 @@ type UpdateProviderResponse struct {
 
 func (x *UpdateProviderResponse) Reset() {
 	*x = UpdateProviderResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[242]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[244]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -19544,7 +19685,7 @@ func (x *UpdateProviderResponse) String() string {
 func (*UpdateProviderResponse) ProtoMessage() {}
 
 func (x *UpdateProviderResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[242]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[244]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -19557,7 +19698,7 @@ func (x *UpdateProviderResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateProviderResponse.ProtoReflect.Descriptor instead.
 func (*UpdateProviderResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{242}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{244}
 }
 
 func (x *UpdateProviderResponse) GetProvider() *LLMProvider {
@@ -19577,7 +19718,7 @@ type DeleteProviderRequest struct {
 
 func (x *DeleteProviderRequest) Reset() {
 	*x = DeleteProviderRequest{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[243]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[245]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -19589,7 +19730,7 @@ func (x *DeleteProviderRequest) String() string {
 func (*DeleteProviderRequest) ProtoMessage() {}
 
 func (x *DeleteProviderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[243]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[245]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -19602,7 +19743,7 @@ func (x *DeleteProviderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteProviderRequest.ProtoReflect.Descriptor instead.
 func (*DeleteProviderRequest) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{243}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{245}
 }
 
 func (x *DeleteProviderRequest) GetId() string {
@@ -19620,7 +19761,7 @@ type DeleteProviderResponse struct {
 
 func (x *DeleteProviderResponse) Reset() {
 	*x = DeleteProviderResponse{}
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[244]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[246]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -19632,7 +19773,7 @@ func (x *DeleteProviderResponse) String() string {
 func (*DeleteProviderResponse) ProtoMessage() {}
 
 func (x *DeleteProviderResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[244]
+	mi := &file_agentcompose_v2_agentcompose_proto_msgTypes[246]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -19645,7 +19786,7 @@ func (x *DeleteProviderResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteProviderResponse.ProtoReflect.Descriptor instead.
 func (*DeleteProviderResponse) Descriptor() ([]byte, []int) {
-	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{244}
+	return file_agentcompose_v2_agentcompose_proto_rawDescGZIP(), []int{246}
 }
 
 var File_agentcompose_v2_agentcompose_proto protoreflect.FileDescriptor
@@ -20990,17 +21131,21 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x03env\x18\x01 \x03(\v2!.agentcompose.v2.EnvVarUpdateSpecR\x03env\"H\n" +
 	"\x17UpdateGlobalEnvResponse\x12-\n" +
 	"\x03env\x18\x01 \x03(\v2\x1b.agentcompose.v2.EnvVarSpecR\x03env\"#\n" +
-	"!GetCapabilityGatewayConfigRequest\"J\n" +
+	"!GetCapabilityGatewayConfigRequest\"r\n" +
 	"\x17CapabilityGatewayConfig\x12\x12\n" +
 	"\x04addr\x18\x01 \x01(\tR\x04addr\x12\x1b\n" +
-	"\ttoken_set\x18\x02 \x01(\bR\btokenSet\"f\n" +
+	"\ttoken_set\x18\x02 \x01(\bR\btokenSet\x12&\n" +
+	"\x0fadmin_token_set\x18\x03 \x01(\bR\radminTokenSet\"f\n" +
 	"\"GetCapabilityGatewayConfigResponse\x12@\n" +
-	"\x06config\x18\x01 \x01(\v2(.agentcompose.v2.CapabilityGatewayConfigR\x06config\"m\n" +
+	"\x06config\x18\x01 \x01(\v2(.agentcompose.v2.CapabilityGatewayConfigR\x06config\"\xa3\x01\n" +
 	"$UpdateCapabilityGatewayConfigRequest\x12\x17\n" +
 	"\x04addr\x18\x01 \x01(\tH\x00R\x04addr\x88\x01\x01\x12\x19\n" +
-	"\x05token\x18\x02 \x01(\tH\x01R\x05token\x88\x01\x01B\a\n" +
+	"\x05token\x18\x02 \x01(\tH\x01R\x05token\x88\x01\x01\x12$\n" +
+	"\vadmin_token\x18\x03 \x01(\tH\x02R\n" +
+	"adminToken\x88\x01\x01B\a\n" +
 	"\x05_addrB\b\n" +
-	"\x06_token\"i\n" +
+	"\x06_tokenB\x0e\n" +
+	"\f_admin_token\"i\n" +
 	"%UpdateCapabilityGatewayConfigResponse\x12@\n" +
 	"\x06config\x18\x01 \x01(\v2(.agentcompose.v2.CapabilityGatewayConfigR\x06config\"\xfa\x01\n" +
 	"\x0fWorkspacePreset\x12\x0e\n" +
@@ -21092,7 +21237,18 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\tcapset_id\x18\x01 \x01(\tR\bcapsetId\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x03 \x01(\tR\vdescription\x12;\n" +
-	"\amethods\x18\x04 \x03(\v2!.agentcompose.v2.CapabilityMethodR\amethods\"h\n" +
+	"\amethods\x18\x04 \x03(\v2!.agentcompose.v2.CapabilityMethodR\amethods\"\xb1\x01\n" +
+	"\x17InvokeCapabilityRequest\x12\x1b\n" +
+	"\tcapset_id\x18\x01 \x01(\tR\bcapsetId\x12\x1f\n" +
+	"\vinstance_id\x18\x02 \x01(\tR\n" +
+	"instanceId\x12\x1d\n" +
+	"\n" +
+	"service_id\x18\x03 \x01(\tR\tserviceId\x12\x16\n" +
+	"\x06method\x18\x04 \x01(\tR\x06method\x12!\n" +
+	"\fpayload_json\x18\x05 \x01(\tR\vpayloadJson\";\n" +
+	"\x18InvokeCapabilityResponse\x12\x1f\n" +
+	"\vresult_json\x18\x01 \x01(\tR\n" +
+	"resultJson\"h\n" +
 	"\x19ListSandboxHistoryRequest\x12\x1d\n" +
 	"\n" +
 	"sandbox_id\x18\x01 \x01(\tR\tsandboxId\x12\x16\n" +
@@ -21506,11 +21662,12 @@ const file_agentcompose_v2_agentcompose_proto_rawDesc = "" +
 	"\x14ListWorkspacePresets\x12,.agentcompose.v2.ListWorkspacePresetsRequest\x1a-.agentcompose.v2.ListWorkspacePresetsResponse\x12p\n" +
 	"\x15CreateWorkspacePreset\x12-.agentcompose.v2.CreateWorkspacePresetRequest\x1a(.agentcompose.v2.WorkspacePresetResponse\x12p\n" +
 	"\x15UpdateWorkspacePreset\x12-.agentcompose.v2.UpdateWorkspacePresetRequest\x1a(.agentcompose.v2.WorkspacePresetResponse\x12v\n" +
-	"\x15DeleteWorkspacePreset\x12-.agentcompose.v2.DeleteWorkspacePresetRequest\x1a..agentcompose.v2.DeleteWorkspacePresetResponse2\xe6\x02\n" +
+	"\x15DeleteWorkspacePreset\x12-.agentcompose.v2.DeleteWorkspacePresetRequest\x1a..agentcompose.v2.DeleteWorkspacePresetResponse2\xcf\x03\n" +
 	"\x11CapabilityService\x12m\n" +
 	"\x13GetCapabilityStatus\x12+.agentcompose.v2.GetCapabilityStatusRequest\x1a).agentcompose.v2.CapabilityStatusResponse\x12m\n" +
 	"\x12ListCapabilitySets\x12*.agentcompose.v2.ListCapabilitySetsRequest\x1a+.agentcompose.v2.ListCapabilitySetsResponse\x12s\n" +
-	"\x14GetCapabilityCatalog\x12,.agentcompose.v2.GetCapabilityCatalogRequest\x1a-.agentcompose.v2.GetCapabilityCatalogResponse2\xc6\x04\n" +
+	"\x14GetCapabilityCatalog\x12,.agentcompose.v2.GetCapabilityCatalogRequest\x1a-.agentcompose.v2.GetCapabilityCatalogResponse\x12g\n" +
+	"\x10InvokeCapability\x12(.agentcompose.v2.InvokeCapabilityRequest\x1a).agentcompose.v2.InvokeCapabilityResponse2\xc6\x04\n" +
 	"\n" +
 	"LLMService\x12a\n" +
 	"\x0eCreateProvider\x12&.agentcompose.v2.CreateProviderRequest\x1a'.agentcompose.v2.CreateProviderResponse\x12X\n" +
@@ -21535,7 +21692,7 @@ func file_agentcompose_v2_agentcompose_proto_rawDescGZIP() []byte {
 }
 
 var file_agentcompose_v2_agentcompose_proto_enumTypes = make([]protoimpl.EnumInfo, 35)
-var file_agentcompose_v2_agentcompose_proto_msgTypes = make([]protoimpl.MessageInfo, 260)
+var file_agentcompose_v2_agentcompose_proto_msgTypes = make([]protoimpl.MessageInfo, 262)
 var file_agentcompose_v2_agentcompose_proto_goTypes = []any{
 	(ProjectValidationSeverity)(0),                // 0: agentcompose.v2.ProjectValidationSeverity
 	(ProjectChangeAction)(0),                      // 1: agentcompose.v2.ProjectChangeAction
@@ -21790,50 +21947,52 @@ var file_agentcompose_v2_agentcompose_proto_goTypes = []any{
 	(*CapabilityEndpoint)(nil),                    // 250: agentcompose.v2.CapabilityEndpoint
 	(*CapabilityMethod)(nil),                      // 251: agentcompose.v2.CapabilityMethod
 	(*GetCapabilityCatalogResponse)(nil),          // 252: agentcompose.v2.GetCapabilityCatalogResponse
-	(*ListSandboxHistoryRequest)(nil),             // 253: agentcompose.v2.ListSandboxHistoryRequest
-	(*SandboxHistoryCell)(nil),                    // 254: agentcompose.v2.SandboxHistoryCell
-	(*SandboxHistoryEvent)(nil),                   // 255: agentcompose.v2.SandboxHistoryEvent
-	(*ListSandboxHistoryResponse)(nil),            // 256: agentcompose.v2.ListSandboxHistoryResponse
-	(*WatchSandboxRequest)(nil),                   // 257: agentcompose.v2.WatchSandboxRequest
-	(*WatchSandboxResponse)(nil),                  // 258: agentcompose.v2.WatchSandboxResponse
-	(*GenerateLLMRequest)(nil),                    // 259: agentcompose.v2.GenerateLLMRequest
-	(*GenerateLLMResponse)(nil),                   // 260: agentcompose.v2.GenerateLLMResponse
-	(*StreamProjectSchedulerEventsRequest)(nil),   // 261: agentcompose.v2.StreamProjectSchedulerEventsRequest
-	(*StreamProjectSchedulerEventsResponse)(nil),  // 262: agentcompose.v2.StreamProjectSchedulerEventsResponse
-	(*StreamSchedulerRunsRequest)(nil),            // 263: agentcompose.v2.StreamSchedulerRunsRequest
-	(*StreamSchedulerRunsResponse)(nil),           // 264: agentcompose.v2.StreamSchedulerRunsResponse
-	(*BatchGetLatestSchedulerRunsRequest)(nil),    // 265: agentcompose.v2.BatchGetLatestSchedulerRunsRequest
-	(*SandboxSchedulerRun)(nil),                   // 266: agentcompose.v2.SandboxSchedulerRun
-	(*BatchGetLatestSchedulerRunsResponse)(nil),   // 267: agentcompose.v2.BatchGetLatestSchedulerRunsResponse
-	(*LLMProvider)(nil),                           // 268: agentcompose.v2.LLMProvider
-	(*LLMProviderSpec)(nil),                       // 269: agentcompose.v2.LLMProviderSpec
-	(*CreateProviderRequest)(nil),                 // 270: agentcompose.v2.CreateProviderRequest
-	(*CreateProviderResponse)(nil),                // 271: agentcompose.v2.CreateProviderResponse
-	(*GetProviderRequest)(nil),                    // 272: agentcompose.v2.GetProviderRequest
-	(*GetProviderResponse)(nil),                   // 273: agentcompose.v2.GetProviderResponse
-	(*ListProvidersRequest)(nil),                  // 274: agentcompose.v2.ListProvidersRequest
-	(*ListProvidersResponse)(nil),                 // 275: agentcompose.v2.ListProvidersResponse
-	(*UpdateProviderRequest)(nil),                 // 276: agentcompose.v2.UpdateProviderRequest
-	(*UpdateProviderResponse)(nil),                // 277: agentcompose.v2.UpdateProviderResponse
-	(*DeleteProviderRequest)(nil),                 // 278: agentcompose.v2.DeleteProviderRequest
-	(*DeleteProviderResponse)(nil),                // 279: agentcompose.v2.DeleteProviderResponse
-	nil,                                           // 280: agentcompose.v2.ProjectVolumeSpec.LabelsEntry
-	nil,                                           // 281: agentcompose.v2.ProjectVolumeSpec.OptionsEntry
-	nil,                                           // 282: agentcompose.v2.BuildSpec.ArgsEntry
-	nil,                                           // 283: agentcompose.v2.RunAgentRequest.LabelsEntry
-	nil,                                           // 284: agentcompose.v2.ListRunsRequest.LabelsEntry
-	nil,                                           // 285: agentcompose.v2.RunDetail.LabelsEntry
-	nil,                                           // 286: agentcompose.v2.AttachHumanMessage.MetadataEntry
-	nil,                                           // 287: agentcompose.v2.AttachError.DetailsEntry
-	nil,                                           // 288: agentcompose.v2.BuildImageRequest.BuildArgsEntry
-	nil,                                           // 289: agentcompose.v2.CreateVolumeRequest.LabelsEntry
-	nil,                                           // 290: agentcompose.v2.CreateVolumeRequest.OptionsEntry
-	nil,                                           // 291: agentcompose.v2.Volume.LabelsEntry
-	nil,                                           // 292: agentcompose.v2.Volume.OptionsEntry
-	nil,                                           // 293: agentcompose.v2.Image.LabelsEntry
-	nil,                                           // 294: agentcompose.v2.CapabilityEndpoint.MetadataEntry
-	(*timestamppb.Timestamp)(nil),                 // 295: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),                   // 296: google.protobuf.Duration
+	(*InvokeCapabilityRequest)(nil),               // 253: agentcompose.v2.InvokeCapabilityRequest
+	(*InvokeCapabilityResponse)(nil),              // 254: agentcompose.v2.InvokeCapabilityResponse
+	(*ListSandboxHistoryRequest)(nil),             // 255: agentcompose.v2.ListSandboxHistoryRequest
+	(*SandboxHistoryCell)(nil),                    // 256: agentcompose.v2.SandboxHistoryCell
+	(*SandboxHistoryEvent)(nil),                   // 257: agentcompose.v2.SandboxHistoryEvent
+	(*ListSandboxHistoryResponse)(nil),            // 258: agentcompose.v2.ListSandboxHistoryResponse
+	(*WatchSandboxRequest)(nil),                   // 259: agentcompose.v2.WatchSandboxRequest
+	(*WatchSandboxResponse)(nil),                  // 260: agentcompose.v2.WatchSandboxResponse
+	(*GenerateLLMRequest)(nil),                    // 261: agentcompose.v2.GenerateLLMRequest
+	(*GenerateLLMResponse)(nil),                   // 262: agentcompose.v2.GenerateLLMResponse
+	(*StreamProjectSchedulerEventsRequest)(nil),   // 263: agentcompose.v2.StreamProjectSchedulerEventsRequest
+	(*StreamProjectSchedulerEventsResponse)(nil),  // 264: agentcompose.v2.StreamProjectSchedulerEventsResponse
+	(*StreamSchedulerRunsRequest)(nil),            // 265: agentcompose.v2.StreamSchedulerRunsRequest
+	(*StreamSchedulerRunsResponse)(nil),           // 266: agentcompose.v2.StreamSchedulerRunsResponse
+	(*BatchGetLatestSchedulerRunsRequest)(nil),    // 267: agentcompose.v2.BatchGetLatestSchedulerRunsRequest
+	(*SandboxSchedulerRun)(nil),                   // 268: agentcompose.v2.SandboxSchedulerRun
+	(*BatchGetLatestSchedulerRunsResponse)(nil),   // 269: agentcompose.v2.BatchGetLatestSchedulerRunsResponse
+	(*LLMProvider)(nil),                           // 270: agentcompose.v2.LLMProvider
+	(*LLMProviderSpec)(nil),                       // 271: agentcompose.v2.LLMProviderSpec
+	(*CreateProviderRequest)(nil),                 // 272: agentcompose.v2.CreateProviderRequest
+	(*CreateProviderResponse)(nil),                // 273: agentcompose.v2.CreateProviderResponse
+	(*GetProviderRequest)(nil),                    // 274: agentcompose.v2.GetProviderRequest
+	(*GetProviderResponse)(nil),                   // 275: agentcompose.v2.GetProviderResponse
+	(*ListProvidersRequest)(nil),                  // 276: agentcompose.v2.ListProvidersRequest
+	(*ListProvidersResponse)(nil),                 // 277: agentcompose.v2.ListProvidersResponse
+	(*UpdateProviderRequest)(nil),                 // 278: agentcompose.v2.UpdateProviderRequest
+	(*UpdateProviderResponse)(nil),                // 279: agentcompose.v2.UpdateProviderResponse
+	(*DeleteProviderRequest)(nil),                 // 280: agentcompose.v2.DeleteProviderRequest
+	(*DeleteProviderResponse)(nil),                // 281: agentcompose.v2.DeleteProviderResponse
+	nil,                                           // 282: agentcompose.v2.ProjectVolumeSpec.LabelsEntry
+	nil,                                           // 283: agentcompose.v2.ProjectVolumeSpec.OptionsEntry
+	nil,                                           // 284: agentcompose.v2.BuildSpec.ArgsEntry
+	nil,                                           // 285: agentcompose.v2.RunAgentRequest.LabelsEntry
+	nil,                                           // 286: agentcompose.v2.ListRunsRequest.LabelsEntry
+	nil,                                           // 287: agentcompose.v2.RunDetail.LabelsEntry
+	nil,                                           // 288: agentcompose.v2.AttachHumanMessage.MetadataEntry
+	nil,                                           // 289: agentcompose.v2.AttachError.DetailsEntry
+	nil,                                           // 290: agentcompose.v2.BuildImageRequest.BuildArgsEntry
+	nil,                                           // 291: agentcompose.v2.CreateVolumeRequest.LabelsEntry
+	nil,                                           // 292: agentcompose.v2.CreateVolumeRequest.OptionsEntry
+	nil,                                           // 293: agentcompose.v2.Volume.LabelsEntry
+	nil,                                           // 294: agentcompose.v2.Volume.OptionsEntry
+	nil,                                           // 295: agentcompose.v2.Image.LabelsEntry
+	nil,                                           // 296: agentcompose.v2.CapabilityEndpoint.MetadataEntry
+	(*timestamppb.Timestamp)(nil),                 // 297: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),                   // 298: google.protobuf.Duration
 }
 var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	91,  // 0: agentcompose.v2.ValidateProjectRequest.spec:type_name -> agentcompose.v2.ProjectSpec
@@ -21862,11 +22021,11 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	91,  // 23: agentcompose.v2.Project.spec:type_name -> agentcompose.v2.ProjectSpec
 	53,  // 24: agentcompose.v2.Project.agents:type_name -> agentcompose.v2.ProjectAgent
 	56,  // 25: agentcompose.v2.Project.schedulers:type_name -> agentcompose.v2.ProjectScheduler
-	295, // 26: agentcompose.v2.ProjectSummary.created_at:type_name -> google.protobuf.Timestamp
-	295, // 27: agentcompose.v2.ProjectSummary.updated_at:type_name -> google.protobuf.Timestamp
-	295, // 28: agentcompose.v2.ProjectSummary.removed_at:type_name -> google.protobuf.Timestamp
+	297, // 26: agentcompose.v2.ProjectSummary.created_at:type_name -> google.protobuf.Timestamp
+	297, // 27: agentcompose.v2.ProjectSummary.updated_at:type_name -> google.protobuf.Timestamp
+	297, // 28: agentcompose.v2.ProjectSummary.removed_at:type_name -> google.protobuf.Timestamp
 	91,  // 29: agentcompose.v2.ProjectRevision.spec:type_name -> agentcompose.v2.ProjectSpec
-	295, // 30: agentcompose.v2.ProjectRevision.created_at:type_name -> google.protobuf.Timestamp
+	297, // 30: agentcompose.v2.ProjectRevision.created_at:type_name -> google.protobuf.Timestamp
 	14,  // 31: agentcompose.v2.ProjectAgent.availability:type_name -> agentcompose.v2.ProjectAgentAvailability
 	15,  // 32: agentcompose.v2.ProjectAgent.health:type_name -> agentcompose.v2.ProjectAgentHealth
 	54,  // 33: agentcompose.v2.ProjectAgent.current_run:type_name -> agentcompose.v2.ProjectAgentCurrentRun
@@ -21874,18 +22033,18 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	32,  // 35: agentcompose.v2.ProjectAgent.model_source:type_name -> agentcompose.v2.AgentModelSource
 	3,   // 36: agentcompose.v2.ProjectAgentLatestRun.status:type_name -> agentcompose.v2.RunStatus
 	4,   // 37: agentcompose.v2.ProjectAgentLatestRun.source:type_name -> agentcompose.v2.RunSource
-	295, // 38: agentcompose.v2.ProjectAgentLatestRun.at:type_name -> google.protobuf.Timestamp
+	297, // 38: agentcompose.v2.ProjectAgentLatestRun.at:type_name -> google.protobuf.Timestamp
 	48,  // 39: agentcompose.v2.GetSchedulerRequest.project:type_name -> agentcompose.v2.ProjectRef
 	56,  // 40: agentcompose.v2.GetSchedulerResponse.scheduler:type_name -> agentcompose.v2.ProjectScheduler
 	103, // 41: agentcompose.v2.GetSchedulerResponse.spec:type_name -> agentcompose.v2.SchedulerSpec
 	59,  // 42: agentcompose.v2.GetSchedulerResponse.triggers:type_name -> agentcompose.v2.ResolvedTrigger
 	104, // 43: agentcompose.v2.ResolvedTrigger.spec:type_name -> agentcompose.v2.TriggerSpec
-	295, // 44: agentcompose.v2.ResolvedTrigger.next_fire_at:type_name -> google.protobuf.Timestamp
-	295, // 45: agentcompose.v2.ResolvedTrigger.last_fired_at:type_name -> google.protobuf.Timestamp
-	295, // 46: agentcompose.v2.SchedulerSummary.latest_run_at:type_name -> google.protobuf.Timestamp
+	297, // 44: agentcompose.v2.ResolvedTrigger.next_fire_at:type_name -> google.protobuf.Timestamp
+	297, // 45: agentcompose.v2.ResolvedTrigger.last_fired_at:type_name -> google.protobuf.Timestamp
+	297, // 46: agentcompose.v2.SchedulerSummary.latest_run_at:type_name -> google.protobuf.Timestamp
 	61,  // 47: agentcompose.v2.ListSchedulersResponse.schedulers:type_name -> agentcompose.v2.SchedulerSummary
 	48,  // 48: agentcompose.v2.ListSchedulerEventsRequest.project:type_name -> agentcompose.v2.ProjectRef
-	295, // 49: agentcompose.v2.SchedulerEvent.created_at:type_name -> google.protobuf.Timestamp
+	297, // 49: agentcompose.v2.SchedulerEvent.created_at:type_name -> google.protobuf.Timestamp
 	64,  // 50: agentcompose.v2.ListSchedulerEventsResponse.events:type_name -> agentcompose.v2.SchedulerEvent
 	48,  // 51: agentcompose.v2.ListProjectSchedulerEventsRequest.project:type_name -> agentcompose.v2.ProjectRef
 	64,  // 52: agentcompose.v2.ListProjectSchedulerEventsResponse.events:type_name -> agentcompose.v2.SchedulerEvent
@@ -21908,8 +22067,8 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	84,  // 69: agentcompose.v2.StopSchedulerRunResponse.run:type_name -> agentcompose.v2.SchedulerRun
 	12,  // 70: agentcompose.v2.SchedulerRun.trigger_kind:type_name -> agentcompose.v2.TriggerKind
 	5,   // 71: agentcompose.v2.SchedulerRun.status:type_name -> agentcompose.v2.SchedulerRunStatus
-	295, // 72: agentcompose.v2.SchedulerRun.started_at:type_name -> google.protobuf.Timestamp
-	295, // 73: agentcompose.v2.SchedulerRun.completed_at:type_name -> google.protobuf.Timestamp
+	297, // 72: agentcompose.v2.SchedulerRun.started_at:type_name -> google.protobuf.Timestamp
+	297, // 73: agentcompose.v2.SchedulerRun.completed_at:type_name -> google.protobuf.Timestamp
 	48,  // 74: agentcompose.v2.SetSchedulerEnabledRequest.project:type_name -> agentcompose.v2.ProjectRef
 	56,  // 75: agentcompose.v2.SetSchedulerEnabledResponse.scheduler:type_name -> agentcompose.v2.ProjectScheduler
 	48,  // 76: agentcompose.v2.SetSchedulerTriggerEnabledRequest.project:type_name -> agentcompose.v2.ProjectRef
@@ -21935,10 +22094,10 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	94,  // 96: agentcompose.v2.AgentSpec.sandbox:type_name -> agentcompose.v2.SandboxSpec
 	100, // 97: agentcompose.v2.MCPServerSpec.env:type_name -> agentcompose.v2.EnvVarSpec
 	100, // 98: agentcompose.v2.MCPServerSpec.headers:type_name -> agentcompose.v2.EnvVarSpec
-	280, // 99: agentcompose.v2.ProjectVolumeSpec.labels:type_name -> agentcompose.v2.ProjectVolumeSpec.LabelsEntry
-	281, // 100: agentcompose.v2.ProjectVolumeSpec.options:type_name -> agentcompose.v2.ProjectVolumeSpec.OptionsEntry
+	282, // 99: agentcompose.v2.ProjectVolumeSpec.labels:type_name -> agentcompose.v2.ProjectVolumeSpec.LabelsEntry
+	283, // 100: agentcompose.v2.ProjectVolumeSpec.options:type_name -> agentcompose.v2.ProjectVolumeSpec.OptionsEntry
 	13,  // 101: agentcompose.v2.VolumeMountSpec.type:type_name -> agentcompose.v2.VolumeMountType
-	282, // 102: agentcompose.v2.BuildSpec.args:type_name -> agentcompose.v2.BuildSpec.ArgsEntry
+	284, // 102: agentcompose.v2.BuildSpec.args:type_name -> agentcompose.v2.BuildSpec.ArgsEntry
 	33,  // 103: agentcompose.v2.WorkspaceSpec.mode:type_name -> agentcompose.v2.WorkspaceMode
 	104, // 104: agentcompose.v2.SchedulerSpec.triggers:type_name -> agentcompose.v2.TriggerSpec
 	11,  // 105: agentcompose.v2.SchedulerSpec.sandbox_policy:type_name -> agentcompose.v2.SchedulerSandboxPolicy
@@ -21955,12 +22114,12 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	18,  // 116: agentcompose.v2.RunAgentRequest.cleanup_policy:type_name -> agentcompose.v2.RunSandboxCleanupPolicy
 	214, // 117: agentcompose.v2.RunAgentRequest.jupyter:type_name -> agentcompose.v2.RunJupyterSpec
 	98,  // 118: agentcompose.v2.RunAgentRequest.volumes:type_name -> agentcompose.v2.VolumeMountSpec
-	283, // 119: agentcompose.v2.RunAgentRequest.labels:type_name -> agentcompose.v2.RunAgentRequest.LabelsEntry
+	285, // 119: agentcompose.v2.RunAgentRequest.labels:type_name -> agentcompose.v2.RunAgentRequest.LabelsEntry
 	152, // 120: agentcompose.v2.RunAgentResponse.run:type_name -> agentcompose.v2.RunDetail
 	17,  // 121: agentcompose.v2.StreamAgentRunResponse.event_type:type_name -> agentcompose.v2.StreamAgentRunEventType
 	151, // 122: agentcompose.v2.StreamAgentRunResponse.run:type_name -> agentcompose.v2.RunSummary
 	22,  // 123: agentcompose.v2.StreamAgentRunResponse.stream:type_name -> agentcompose.v2.StdioStream
-	295, // 124: agentcompose.v2.StreamAgentRunResponse.created_at:type_name -> google.protobuf.Timestamp
+	297, // 124: agentcompose.v2.StreamAgentRunResponse.created_at:type_name -> google.protobuf.Timestamp
 	117, // 125: agentcompose.v2.StreamAgentRunResponse.transcript:type_name -> agentcompose.v2.TranscriptEvent
 	116, // 126: agentcompose.v2.AttachAgentRunRequest.start:type_name -> agentcompose.v2.AttachAgentRunStart
 	162, // 127: agentcompose.v2.AttachAgentRunRequest.stdin:type_name -> agentcompose.v2.AttachStdin
@@ -21969,7 +22128,7 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	165, // 130: agentcompose.v2.AttachAgentRunRequest.signal:type_name -> agentcompose.v2.AttachSignal
 	166, // 131: agentcompose.v2.AttachAgentRunRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
 	167, // 132: agentcompose.v2.AttachAgentRunRequest.cancel:type_name -> agentcompose.v2.AttachCancel
-	295, // 133: agentcompose.v2.AttachAgentRunResponse.created_at:type_name -> google.protobuf.Timestamp
+	297, // 133: agentcompose.v2.AttachAgentRunResponse.created_at:type_name -> google.protobuf.Timestamp
 	168, // 134: agentcompose.v2.AttachAgentRunResponse.started:type_name -> agentcompose.v2.AttachStarted
 	169, // 135: agentcompose.v2.AttachAgentRunResponse.output:type_name -> agentcompose.v2.AttachOutput
 	170, // 136: agentcompose.v2.AttachAgentRunResponse.agent_event:type_name -> agentcompose.v2.AttachAgentEvent
@@ -21981,49 +22140,49 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	161, // 142: agentcompose.v2.AttachAgentRunStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
 	21,  // 143: agentcompose.v2.AttachAgentRunStart.disconnect_policy:type_name -> agentcompose.v2.AttachDisconnectPolicy
 	22,  // 144: agentcompose.v2.TranscriptEvent.stream:type_name -> agentcompose.v2.StdioStream
-	295, // 145: agentcompose.v2.TranscriptEvent.created_at:type_name -> google.protobuf.Timestamp
+	297, // 145: agentcompose.v2.TranscriptEvent.created_at:type_name -> google.protobuf.Timestamp
 	152, // 146: agentcompose.v2.GetRunResponse.run:type_name -> agentcompose.v2.RunDetail
 	3,   // 147: agentcompose.v2.ListRunsRequest.status:type_name -> agentcompose.v2.RunStatus
 	4,   // 148: agentcompose.v2.ListRunsRequest.source:type_name -> agentcompose.v2.RunSource
-	295, // 149: agentcompose.v2.ListRunsRequest.started_from:type_name -> google.protobuf.Timestamp
-	295, // 150: agentcompose.v2.ListRunsRequest.started_to:type_name -> google.protobuf.Timestamp
-	284, // 151: agentcompose.v2.ListRunsRequest.labels:type_name -> agentcompose.v2.ListRunsRequest.LabelsEntry
+	297, // 149: agentcompose.v2.ListRunsRequest.started_from:type_name -> google.protobuf.Timestamp
+	297, // 150: agentcompose.v2.ListRunsRequest.started_to:type_name -> google.protobuf.Timestamp
+	286, // 151: agentcompose.v2.ListRunsRequest.labels:type_name -> agentcompose.v2.ListRunsRequest.LabelsEntry
 	151, // 152: agentcompose.v2.ListRunsResponse.runs:type_name -> agentcompose.v2.RunSummary
 	3,   // 153: agentcompose.v2.RunLogChunk.run_status:type_name -> agentcompose.v2.RunStatus
-	295, // 154: agentcompose.v2.RunLogChunk.created_at:type_name -> google.protobuf.Timestamp
+	297, // 154: agentcompose.v2.RunLogChunk.created_at:type_name -> google.protobuf.Timestamp
 	151, // 155: agentcompose.v2.RunLogChunk.run:type_name -> agentcompose.v2.RunSummary
 	152, // 156: agentcompose.v2.StopRunResponse.run:type_name -> agentcompose.v2.RunDetail
 	16,  // 157: agentcompose.v2.RunEvent.kind:type_name -> agentcompose.v2.RunEventKind
-	295, // 158: agentcompose.v2.RunEvent.created_at:type_name -> google.protobuf.Timestamp
+	297, // 158: agentcompose.v2.RunEvent.created_at:type_name -> google.protobuf.Timestamp
 	127, // 159: agentcompose.v2.ListRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
 	127, // 160: agentcompose.v2.ListSandboxRunEventsResponse.events:type_name -> agentcompose.v2.RunEvent
 	6,   // 161: agentcompose.v2.PruneSandboxesRequest.status:type_name -> agentcompose.v2.SandboxStatus
 	29,  // 162: agentcompose.v2.SandboxPruneCandidate.kind:type_name -> agentcompose.v2.SandboxPruneCandidateKind
 	6,   // 163: agentcompose.v2.SandboxPruneCandidate.status:type_name -> agentcompose.v2.SandboxStatus
-	295, // 164: agentcompose.v2.SandboxPruneCandidate.updated_at:type_name -> google.protobuf.Timestamp
+	297, // 164: agentcompose.v2.SandboxPruneCandidate.updated_at:type_name -> google.protobuf.Timestamp
 	134, // 165: agentcompose.v2.PruneSandboxesResponse.matched:type_name -> agentcompose.v2.SandboxPruneCandidate
 	134, // 166: agentcompose.v2.PruneSandboxesResponse.skipped:type_name -> agentcompose.v2.SandboxPruneCandidate
 	150, // 167: agentcompose.v2.GetSandboxStatsResponse.stats:type_name -> agentcompose.v2.SandboxStats
 	6,   // 168: agentcompose.v2.Sandbox.status:type_name -> agentcompose.v2.SandboxStatus
-	295, // 169: agentcompose.v2.Sandbox.created_at:type_name -> google.protobuf.Timestamp
-	295, // 170: agentcompose.v2.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
+	297, // 169: agentcompose.v2.Sandbox.created_at:type_name -> google.protobuf.Timestamp
+	297, // 170: agentcompose.v2.Sandbox.updated_at:type_name -> google.protobuf.Timestamp
 	141, // 171: agentcompose.v2.Sandbox.tags:type_name -> agentcompose.v2.SandboxTag
 	9,   // 172: agentcompose.v2.Sandbox.workspace_reclamation_state:type_name -> agentcompose.v2.WorkspaceReclamationState
-	295, // 173: agentcompose.v2.Sandbox.workspace_reclamation_started_at:type_name -> google.protobuf.Timestamp
-	295, // 174: agentcompose.v2.Sandbox.workspace_reclamation_completed_at:type_name -> google.protobuf.Timestamp
-	295, // 175: agentcompose.v2.Sandbox.stopped_runtime_released_at:type_name -> google.protobuf.Timestamp
+	297, // 173: agentcompose.v2.Sandbox.workspace_reclamation_started_at:type_name -> google.protobuf.Timestamp
+	297, // 174: agentcompose.v2.Sandbox.workspace_reclamation_completed_at:type_name -> google.protobuf.Timestamp
+	297, // 175: agentcompose.v2.Sandbox.stopped_runtime_released_at:type_name -> google.protobuf.Timestamp
 	140, // 176: agentcompose.v2.Sandbox.workspace_delivery:type_name -> agentcompose.v2.SandboxWorkspaceDelivery
 	33,  // 177: agentcompose.v2.SandboxWorkspaceDelivery.mode:type_name -> agentcompose.v2.WorkspaceMode
 	6,   // 178: agentcompose.v2.ListSandboxesRequest.status:type_name -> agentcompose.v2.SandboxStatus
 	139, // 179: agentcompose.v2.ListSandboxesResponse.sandboxes:type_name -> agentcompose.v2.Sandbox
 	139, // 180: agentcompose.v2.GetSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
 	7,   // 181: agentcompose.v2.StopSandboxRequest.mode:type_name -> agentcompose.v2.SandboxStopMode
-	296, // 182: agentcompose.v2.StopSandboxRequest.grace_period:type_name -> google.protobuf.Duration
+	298, // 182: agentcompose.v2.StopSandboxRequest.grace_period:type_name -> google.protobuf.Duration
 	139, // 183: agentcompose.v2.StopSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
 	8,   // 184: agentcompose.v2.StopSandboxResponse.outcome:type_name -> agentcompose.v2.SandboxStopOutcome
 	139, // 185: agentcompose.v2.ResumeSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
 	26,  // 186: agentcompose.v2.MetricValue.status:type_name -> agentcompose.v2.MetricStatus
-	295, // 187: agentcompose.v2.SandboxStats.sampled_at:type_name -> google.protobuf.Timestamp
+	297, // 187: agentcompose.v2.SandboxStats.sampled_at:type_name -> google.protobuf.Timestamp
 	149, // 188: agentcompose.v2.SandboxStats.cpu_percent:type_name -> agentcompose.v2.MetricValue
 	149, // 189: agentcompose.v2.SandboxStats.memory_usage_bytes:type_name -> agentcompose.v2.MetricValue
 	149, // 190: agentcompose.v2.SandboxStats.memory_limit_bytes:type_name -> agentcompose.v2.MetricValue
@@ -22035,12 +22194,12 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	149, // 196: agentcompose.v2.SandboxStats.uptime_seconds:type_name -> agentcompose.v2.MetricValue
 	4,   // 197: agentcompose.v2.RunSummary.source:type_name -> agentcompose.v2.RunSource
 	3,   // 198: agentcompose.v2.RunSummary.status:type_name -> agentcompose.v2.RunStatus
-	295, // 199: agentcompose.v2.RunSummary.started_at:type_name -> google.protobuf.Timestamp
-	295, // 200: agentcompose.v2.RunSummary.completed_at:type_name -> google.protobuf.Timestamp
-	295, // 201: agentcompose.v2.RunSummary.created_at:type_name -> google.protobuf.Timestamp
-	295, // 202: agentcompose.v2.RunSummary.updated_at:type_name -> google.protobuf.Timestamp
+	297, // 199: agentcompose.v2.RunSummary.started_at:type_name -> google.protobuf.Timestamp
+	297, // 200: agentcompose.v2.RunSummary.completed_at:type_name -> google.protobuf.Timestamp
+	297, // 201: agentcompose.v2.RunSummary.created_at:type_name -> google.protobuf.Timestamp
+	297, // 202: agentcompose.v2.RunSummary.updated_at:type_name -> google.protobuf.Timestamp
 	151, // 203: agentcompose.v2.RunDetail.summary:type_name -> agentcompose.v2.RunSummary
-	285, // 204: agentcompose.v2.RunDetail.labels:type_name -> agentcompose.v2.RunDetail.LabelsEntry
+	287, // 204: agentcompose.v2.RunDetail.labels:type_name -> agentcompose.v2.RunDetail.LabelsEntry
 	154, // 205: agentcompose.v2.ExecRequest.selector:type_name -> agentcompose.v2.ExecSandboxSelector
 	155, // 206: agentcompose.v2.ExecRequest.command:type_name -> agentcompose.v2.ExecCommand
 	100, // 207: agentcompose.v2.ExecRequest.env:type_name -> agentcompose.v2.EnvVarSpec
@@ -22056,7 +22215,7 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	165, // 217: agentcompose.v2.AttachExecRequest.signal:type_name -> agentcompose.v2.AttachSignal
 	167, // 218: agentcompose.v2.AttachExecRequest.cancel:type_name -> agentcompose.v2.AttachCancel
 	166, // 219: agentcompose.v2.AttachExecRequest.human_message:type_name -> agentcompose.v2.AttachHumanMessage
-	295, // 220: agentcompose.v2.AttachExecResponse.created_at:type_name -> google.protobuf.Timestamp
+	297, // 220: agentcompose.v2.AttachExecResponse.created_at:type_name -> google.protobuf.Timestamp
 	168, // 221: agentcompose.v2.AttachExecResponse.started:type_name -> agentcompose.v2.AttachStarted
 	169, // 222: agentcompose.v2.AttachExecResponse.output:type_name -> agentcompose.v2.AttachOutput
 	172, // 223: agentcompose.v2.AttachExecResponse.result:type_name -> agentcompose.v2.AttachResult
@@ -22067,14 +22226,14 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	161, // 228: agentcompose.v2.AttachExecStart.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
 	20,  // 229: agentcompose.v2.AttachExecStart.mode:type_name -> agentcompose.v2.AttachRunMode
 	161, // 230: agentcompose.v2.AttachResize.terminal_size:type_name -> agentcompose.v2.AttachTerminalSize
-	286, // 231: agentcompose.v2.AttachHumanMessage.metadata:type_name -> agentcompose.v2.AttachHumanMessage.MetadataEntry
+	288, // 231: agentcompose.v2.AttachHumanMessage.metadata:type_name -> agentcompose.v2.AttachHumanMessage.MetadataEntry
 	151, // 232: agentcompose.v2.AttachStarted.run:type_name -> agentcompose.v2.RunSummary
 	22,  // 233: agentcompose.v2.AttachOutput.stream:type_name -> agentcompose.v2.StdioStream
 	117, // 234: agentcompose.v2.AttachOutput.transcript:type_name -> agentcompose.v2.TranscriptEvent
-	295, // 235: agentcompose.v2.AttachAgentEvent.created_at:type_name -> google.protobuf.Timestamp
+	297, // 235: agentcompose.v2.AttachAgentEvent.created_at:type_name -> google.protobuf.Timestamp
 	174, // 236: agentcompose.v2.AttachResult.exec_result:type_name -> agentcompose.v2.ExecResult
 	151, // 237: agentcompose.v2.AttachResult.run:type_name -> agentcompose.v2.RunSummary
-	287, // 238: agentcompose.v2.AttachError.details:type_name -> agentcompose.v2.AttachError.DetailsEntry
+	289, // 238: agentcompose.v2.AttachError.details:type_name -> agentcompose.v2.AttachError.DetailsEntry
 	155, // 239: agentcompose.v2.ExecResult.command:type_name -> agentcompose.v2.ExecCommand
 	23,  // 240: agentcompose.v2.ListImagesRequest.store:type_name -> agentcompose.v2.ImageStoreKind
 	207, // 241: agentcompose.v2.ListImagesResponse.images:type_name -> agentcompose.v2.Image
@@ -22088,7 +22247,7 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	207, // 249: agentcompose.v2.InspectImageResponse.image:type_name -> agentcompose.v2.Image
 	209, // 250: agentcompose.v2.InspectImageResponse.store_status:type_name -> agentcompose.v2.ImageStoreStatus
 	23,  // 251: agentcompose.v2.RemoveImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
-	288, // 252: agentcompose.v2.BuildImageRequest.build_args:type_name -> agentcompose.v2.BuildImageRequest.BuildArgsEntry
+	290, // 252: agentcompose.v2.BuildImageRequest.build_args:type_name -> agentcompose.v2.BuildImageRequest.BuildArgsEntry
 	23,  // 253: agentcompose.v2.BuildImageRequest.store:type_name -> agentcompose.v2.ImageStoreKind
 	208, // 254: agentcompose.v2.BuildImageRequest.platform:type_name -> agentcompose.v2.ImagePlatform
 	25,  // 255: agentcompose.v2.BuildImageEvent.status:type_name -> agentcompose.v2.ImageOperationStatus
@@ -22105,29 +22264,29 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	194, // 266: agentcompose.v2.RemoveCacheResponse.skipped:type_name -> agentcompose.v2.CacheItem
 	27,  // 267: agentcompose.v2.CacheItem.domain:type_name -> agentcompose.v2.CacheDomain
 	30,  // 268: agentcompose.v2.CacheItem.status:type_name -> agentcompose.v2.CacheStatus
-	295, // 269: agentcompose.v2.CacheItem.last_used_at:type_name -> google.protobuf.Timestamp
+	297, // 269: agentcompose.v2.CacheItem.last_used_at:type_name -> google.protobuf.Timestamp
 	195, // 270: agentcompose.v2.CacheItem.references:type_name -> agentcompose.v2.CacheReference
 	28,  // 271: agentcompose.v2.CacheReference.policy:type_name -> agentcompose.v2.CacheReferencePolicy
 	206, // 272: agentcompose.v2.ListVolumesResponse.volumes:type_name -> agentcompose.v2.Volume
-	289, // 273: agentcompose.v2.CreateVolumeRequest.labels:type_name -> agentcompose.v2.CreateVolumeRequest.LabelsEntry
-	290, // 274: agentcompose.v2.CreateVolumeRequest.options:type_name -> agentcompose.v2.CreateVolumeRequest.OptionsEntry
+	291, // 273: agentcompose.v2.CreateVolumeRequest.labels:type_name -> agentcompose.v2.CreateVolumeRequest.LabelsEntry
+	292, // 274: agentcompose.v2.CreateVolumeRequest.options:type_name -> agentcompose.v2.CreateVolumeRequest.OptionsEntry
 	206, // 275: agentcompose.v2.CreateVolumeResponse.volume:type_name -> agentcompose.v2.Volume
 	206, // 276: agentcompose.v2.InspectVolumeResponse.volume:type_name -> agentcompose.v2.Volume
 	206, // 277: agentcompose.v2.PruneVolumesResponse.matched:type_name -> agentcompose.v2.Volume
 	206, // 278: agentcompose.v2.PruneVolumesResponse.removed:type_name -> agentcompose.v2.Volume
 	206, // 279: agentcompose.v2.PruneVolumesResponse.skipped:type_name -> agentcompose.v2.Volume
-	291, // 280: agentcompose.v2.Volume.labels:type_name -> agentcompose.v2.Volume.LabelsEntry
-	292, // 281: agentcompose.v2.Volume.options:type_name -> agentcompose.v2.Volume.OptionsEntry
-	295, // 282: agentcompose.v2.Volume.created_at:type_name -> google.protobuf.Timestamp
-	295, // 283: agentcompose.v2.Volume.updated_at:type_name -> google.protobuf.Timestamp
+	293, // 280: agentcompose.v2.Volume.labels:type_name -> agentcompose.v2.Volume.LabelsEntry
+	294, // 281: agentcompose.v2.Volume.options:type_name -> agentcompose.v2.Volume.OptionsEntry
+	297, // 282: agentcompose.v2.Volume.created_at:type_name -> google.protobuf.Timestamp
+	297, // 283: agentcompose.v2.Volume.updated_at:type_name -> google.protobuf.Timestamp
 	23,  // 284: agentcompose.v2.Image.store:type_name -> agentcompose.v2.ImageStoreKind
 	24,  // 285: agentcompose.v2.Image.availability_status:type_name -> agentcompose.v2.ImageAvailabilityStatus
 	208, // 286: agentcompose.v2.Image.platform:type_name -> agentcompose.v2.ImagePlatform
-	295, // 287: agentcompose.v2.Image.created_at:type_name -> google.protobuf.Timestamp
-	295, // 288: agentcompose.v2.Image.inspected_at:type_name -> google.protobuf.Timestamp
+	297, // 287: agentcompose.v2.Image.created_at:type_name -> google.protobuf.Timestamp
+	297, // 288: agentcompose.v2.Image.inspected_at:type_name -> google.protobuf.Timestamp
 	210, // 289: agentcompose.v2.Image.docker:type_name -> agentcompose.v2.DockerImageStatus
 	211, // 290: agentcompose.v2.Image.oci:type_name -> agentcompose.v2.OCIImageStatus
-	293, // 291: agentcompose.v2.Image.labels:type_name -> agentcompose.v2.Image.LabelsEntry
+	295, // 291: agentcompose.v2.Image.labels:type_name -> agentcompose.v2.Image.LabelsEntry
 	23,  // 292: agentcompose.v2.ImageStoreStatus.store:type_name -> agentcompose.v2.ImageStoreKind
 	111, // 293: agentcompose.v2.StartAgentRunRequest.run:type_name -> agentcompose.v2.RunAgentRequest
 	151, // 294: agentcompose.v2.StartAgentRunResponse.run:type_name -> agentcompose.v2.RunSummary
@@ -22135,7 +22294,7 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	220, // 296: agentcompose.v2.ResolveResourceIDResponse.targets:type_name -> agentcompose.v2.ResourceTarget
 	31,  // 297: agentcompose.v2.ResourceTarget.kind:type_name -> agentcompose.v2.ResourceKind
 	223, // 298: agentcompose.v2.DashboardOverview.runs:type_name -> agentcompose.v2.RunOverview
-	295, // 299: agentcompose.v2.DashboardOverview.updated_at:type_name -> google.protobuf.Timestamp
+	297, // 299: agentcompose.v2.DashboardOverview.updated_at:type_name -> google.protobuf.Timestamp
 	224, // 300: agentcompose.v2.GetDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
 	224, // 301: agentcompose.v2.WatchDashboardOverviewResponse.overview:type_name -> agentcompose.v2.DashboardOverview
 	100, // 302: agentcompose.v2.GetGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
@@ -22143,22 +22302,22 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	100, // 304: agentcompose.v2.UpdateGlobalEnvResponse.env:type_name -> agentcompose.v2.EnvVarSpec
 	232, // 305: agentcompose.v2.GetCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
 	232, // 306: agentcompose.v2.UpdateCapabilityGatewayConfigResponse.config:type_name -> agentcompose.v2.CapabilityGatewayConfig
-	295, // 307: agentcompose.v2.WorkspacePreset.created_at:type_name -> google.protobuf.Timestamp
-	295, // 308: agentcompose.v2.WorkspacePreset.updated_at:type_name -> google.protobuf.Timestamp
+	297, // 307: agentcompose.v2.WorkspacePreset.created_at:type_name -> google.protobuf.Timestamp
+	297, // 308: agentcompose.v2.WorkspacePreset.updated_at:type_name -> google.protobuf.Timestamp
 	236, // 309: agentcompose.v2.ListWorkspacePresetsResponse.presets:type_name -> agentcompose.v2.WorkspacePreset
 	236, // 310: agentcompose.v2.WorkspacePresetResponse.preset:type_name -> agentcompose.v2.WorkspacePreset
 	247, // 311: agentcompose.v2.ListCapabilitySetsResponse.capsets:type_name -> agentcompose.v2.CapabilitySet
-	294, // 312: agentcompose.v2.CapabilityEndpoint.metadata:type_name -> agentcompose.v2.CapabilityEndpoint.MetadataEntry
+	296, // 312: agentcompose.v2.CapabilityEndpoint.metadata:type_name -> agentcompose.v2.CapabilityEndpoint.MetadataEntry
 	250, // 313: agentcompose.v2.CapabilityMethod.endpoints:type_name -> agentcompose.v2.CapabilityEndpoint
 	251, // 314: agentcompose.v2.GetCapabilityCatalogResponse.methods:type_name -> agentcompose.v2.CapabilityMethod
-	295, // 315: agentcompose.v2.SandboxHistoryCell.created_at:type_name -> google.protobuf.Timestamp
-	295, // 316: agentcompose.v2.SandboxHistoryEvent.created_at:type_name -> google.protobuf.Timestamp
-	254, // 317: agentcompose.v2.ListSandboxHistoryResponse.cells:type_name -> agentcompose.v2.SandboxHistoryCell
-	255, // 318: agentcompose.v2.ListSandboxHistoryResponse.events:type_name -> agentcompose.v2.SandboxHistoryEvent
+	297, // 315: agentcompose.v2.SandboxHistoryCell.created_at:type_name -> google.protobuf.Timestamp
+	297, // 316: agentcompose.v2.SandboxHistoryEvent.created_at:type_name -> google.protobuf.Timestamp
+	256, // 317: agentcompose.v2.ListSandboxHistoryResponse.cells:type_name -> agentcompose.v2.SandboxHistoryCell
+	257, // 318: agentcompose.v2.ListSandboxHistoryResponse.events:type_name -> agentcompose.v2.SandboxHistoryEvent
 	34,  // 319: agentcompose.v2.WatchSandboxResponse.event_type:type_name -> agentcompose.v2.SandboxWatchEventType
 	139, // 320: agentcompose.v2.WatchSandboxResponse.sandbox:type_name -> agentcompose.v2.Sandbox
-	254, // 321: agentcompose.v2.WatchSandboxResponse.cell:type_name -> agentcompose.v2.SandboxHistoryCell
-	255, // 322: agentcompose.v2.WatchSandboxResponse.event:type_name -> agentcompose.v2.SandboxHistoryEvent
+	256, // 321: agentcompose.v2.WatchSandboxResponse.cell:type_name -> agentcompose.v2.SandboxHistoryCell
+	257, // 322: agentcompose.v2.WatchSandboxResponse.event:type_name -> agentcompose.v2.SandboxHistoryEvent
 	22,  // 323: agentcompose.v2.WatchSandboxResponse.stream:type_name -> agentcompose.v2.StdioStream
 	48,  // 324: agentcompose.v2.StreamProjectSchedulerEventsRequest.project:type_name -> agentcompose.v2.ProjectRef
 	64,  // 325: agentcompose.v2.StreamProjectSchedulerEventsResponse.events:type_name -> agentcompose.v2.SchedulerEvent
@@ -22167,15 +22326,15 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	84,  // 328: agentcompose.v2.StreamSchedulerRunsResponse.runs:type_name -> agentcompose.v2.SchedulerRun
 	48,  // 329: agentcompose.v2.BatchGetLatestSchedulerRunsRequest.project:type_name -> agentcompose.v2.ProjectRef
 	84,  // 330: agentcompose.v2.SandboxSchedulerRun.run:type_name -> agentcompose.v2.SchedulerRun
-	266, // 331: agentcompose.v2.BatchGetLatestSchedulerRunsResponse.results:type_name -> agentcompose.v2.SandboxSchedulerRun
-	295, // 332: agentcompose.v2.LLMProvider.created_at:type_name -> google.protobuf.Timestamp
-	295, // 333: agentcompose.v2.LLMProvider.updated_at:type_name -> google.protobuf.Timestamp
-	269, // 334: agentcompose.v2.CreateProviderRequest.provider:type_name -> agentcompose.v2.LLMProviderSpec
-	268, // 335: agentcompose.v2.CreateProviderResponse.provider:type_name -> agentcompose.v2.LLMProvider
-	268, // 336: agentcompose.v2.GetProviderResponse.provider:type_name -> agentcompose.v2.LLMProvider
-	268, // 337: agentcompose.v2.ListProvidersResponse.providers:type_name -> agentcompose.v2.LLMProvider
-	269, // 338: agentcompose.v2.UpdateProviderRequest.provider:type_name -> agentcompose.v2.LLMProviderSpec
-	268, // 339: agentcompose.v2.UpdateProviderResponse.provider:type_name -> agentcompose.v2.LLMProvider
+	268, // 331: agentcompose.v2.BatchGetLatestSchedulerRunsResponse.results:type_name -> agentcompose.v2.SandboxSchedulerRun
+	297, // 332: agentcompose.v2.LLMProvider.created_at:type_name -> google.protobuf.Timestamp
+	297, // 333: agentcompose.v2.LLMProvider.updated_at:type_name -> google.protobuf.Timestamp
+	271, // 334: agentcompose.v2.CreateProviderRequest.provider:type_name -> agentcompose.v2.LLMProviderSpec
+	270, // 335: agentcompose.v2.CreateProviderResponse.provider:type_name -> agentcompose.v2.LLMProvider
+	270, // 336: agentcompose.v2.GetProviderResponse.provider:type_name -> agentcompose.v2.LLMProvider
+	270, // 337: agentcompose.v2.ListProvidersResponse.providers:type_name -> agentcompose.v2.LLMProvider
+	271, // 338: agentcompose.v2.UpdateProviderRequest.provider:type_name -> agentcompose.v2.LLMProviderSpec
+	270, // 339: agentcompose.v2.UpdateProviderResponse.provider:type_name -> agentcompose.v2.LLMProvider
 	35,  // 340: agentcompose.v2.ProjectService.ValidateProject:input_type -> agentcompose.v2.ValidateProjectRequest
 	37,  // 341: agentcompose.v2.ProjectService.ApplyProject:input_type -> agentcompose.v2.ApplyProjectRequest
 	39,  // 342: agentcompose.v2.ProjectService.PatchProject:input_type -> agentcompose.v2.PatchProjectRequest
@@ -22187,14 +22346,14 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	60,  // 348: agentcompose.v2.ProjectService.ListSchedulers:input_type -> agentcompose.v2.ListSchedulersRequest
 	63,  // 349: agentcompose.v2.ProjectService.ListSchedulerEvents:input_type -> agentcompose.v2.ListSchedulerEventsRequest
 	66,  // 350: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:input_type -> agentcompose.v2.ListProjectSchedulerEventsRequest
-	261, // 351: agentcompose.v2.ProjectService.StreamProjectSchedulerEvents:input_type -> agentcompose.v2.StreamProjectSchedulerEventsRequest
+	263, // 351: agentcompose.v2.ProjectService.StreamProjectSchedulerEvents:input_type -> agentcompose.v2.StreamProjectSchedulerEventsRequest
 	68,  // 352: agentcompose.v2.ProjectService.InvokeScheduler:input_type -> agentcompose.v2.InvokeSchedulerRequest
 	70,  // 353: agentcompose.v2.ProjectService.RunScheduler:input_type -> agentcompose.v2.RunSchedulerRequest
 	72,  // 354: agentcompose.v2.ProjectService.StartSchedulerRun:input_type -> agentcompose.v2.StartSchedulerRunRequest
 	74,  // 355: agentcompose.v2.ProjectService.GetSchedulerRun:input_type -> agentcompose.v2.GetSchedulerRunRequest
 	76,  // 356: agentcompose.v2.ProjectService.ListSchedulerRuns:input_type -> agentcompose.v2.ListSchedulerRunsRequest
-	265, // 357: agentcompose.v2.ProjectService.BatchGetLatestSchedulerRuns:input_type -> agentcompose.v2.BatchGetLatestSchedulerRunsRequest
-	263, // 358: agentcompose.v2.ProjectService.StreamSchedulerRuns:input_type -> agentcompose.v2.StreamSchedulerRunsRequest
+	267, // 357: agentcompose.v2.ProjectService.BatchGetLatestSchedulerRuns:input_type -> agentcompose.v2.BatchGetLatestSchedulerRunsRequest
+	265, // 358: agentcompose.v2.ProjectService.StreamSchedulerRuns:input_type -> agentcompose.v2.StreamSchedulerRunsRequest
 	78,  // 359: agentcompose.v2.ProjectService.PruneSchedulerRuns:input_type -> agentcompose.v2.PruneSchedulerRunsRequest
 	82,  // 360: agentcompose.v2.ProjectService.StopSchedulerRun:input_type -> agentcompose.v2.StopSchedulerRunRequest
 	85,  // 361: agentcompose.v2.ProjectService.SetSchedulerEnabled:input_type -> agentcompose.v2.SetSchedulerEnabledRequest
@@ -22233,8 +22392,8 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	145, // 394: agentcompose.v2.SandboxService.StopSandbox:input_type -> agentcompose.v2.StopSandboxRequest
 	147, // 395: agentcompose.v2.SandboxService.ResumeSandbox:input_type -> agentcompose.v2.ResumeSandboxRequest
 	142, // 396: agentcompose.v2.SandboxService.ListSandboxes:input_type -> agentcompose.v2.ListSandboxesRequest
-	253, // 397: agentcompose.v2.SandboxService.ListSandboxHistory:input_type -> agentcompose.v2.ListSandboxHistoryRequest
-	257, // 398: agentcompose.v2.SandboxService.WatchSandbox:input_type -> agentcompose.v2.WatchSandboxRequest
+	255, // 397: agentcompose.v2.SandboxService.ListSandboxHistory:input_type -> agentcompose.v2.ListSandboxHistoryRequest
+	259, // 398: agentcompose.v2.SandboxService.WatchSandbox:input_type -> agentcompose.v2.WatchSandboxRequest
 	221, // 399: agentcompose.v2.DashboardService.GetDashboardOverview:input_type -> agentcompose.v2.GetDashboardOverviewRequest
 	222, // 400: agentcompose.v2.DashboardService.WatchDashboardOverview:input_type -> agentcompose.v2.WatchDashboardOverviewRequest
 	227, // 401: agentcompose.v2.SettingsService.GetGlobalEnv:input_type -> agentcompose.v2.GetGlobalEnvRequest
@@ -22248,94 +22407,96 @@ var file_agentcompose_v2_agentcompose_proto_depIdxs = []int32{
 	244, // 409: agentcompose.v2.CapabilityService.GetCapabilityStatus:input_type -> agentcompose.v2.GetCapabilityStatusRequest
 	246, // 410: agentcompose.v2.CapabilityService.ListCapabilitySets:input_type -> agentcompose.v2.ListCapabilitySetsRequest
 	249, // 411: agentcompose.v2.CapabilityService.GetCapabilityCatalog:input_type -> agentcompose.v2.GetCapabilityCatalogRequest
-	270, // 412: agentcompose.v2.LLMService.CreateProvider:input_type -> agentcompose.v2.CreateProviderRequest
-	272, // 413: agentcompose.v2.LLMService.GetProvider:input_type -> agentcompose.v2.GetProviderRequest
-	274, // 414: agentcompose.v2.LLMService.ListProviders:input_type -> agentcompose.v2.ListProvidersRequest
-	276, // 415: agentcompose.v2.LLMService.UpdateProvider:input_type -> agentcompose.v2.UpdateProviderRequest
-	278, // 416: agentcompose.v2.LLMService.DeleteProvider:input_type -> agentcompose.v2.DeleteProviderRequest
-	259, // 417: agentcompose.v2.LLMService.Generate:input_type -> agentcompose.v2.GenerateLLMRequest
-	218, // 418: agentcompose.v2.ResourceService.ResolveID:input_type -> agentcompose.v2.ResolveResourceIDRequest
-	36,  // 419: agentcompose.v2.ProjectService.ValidateProject:output_type -> agentcompose.v2.ValidateProjectResponse
-	38,  // 420: agentcompose.v2.ProjectService.ApplyProject:output_type -> agentcompose.v2.ApplyProjectResponse
-	38,  // 421: agentcompose.v2.ProjectService.PatchProject:output_type -> agentcompose.v2.ApplyProjectResponse
-	41,  // 422: agentcompose.v2.ProjectService.GetProject:output_type -> agentcompose.v2.GetProjectResponse
-	43,  // 423: agentcompose.v2.ProjectService.ListProjects:output_type -> agentcompose.v2.ListProjectsResponse
-	45,  // 424: agentcompose.v2.ProjectService.RemoveProject:output_type -> agentcompose.v2.RemoveProjectResponse
-	47,  // 425: agentcompose.v2.ProjectService.WatchProject:output_type -> agentcompose.v2.WatchProjectResponse
-	58,  // 426: agentcompose.v2.ProjectService.GetScheduler:output_type -> agentcompose.v2.GetSchedulerResponse
-	62,  // 427: agentcompose.v2.ProjectService.ListSchedulers:output_type -> agentcompose.v2.ListSchedulersResponse
-	65,  // 428: agentcompose.v2.ProjectService.ListSchedulerEvents:output_type -> agentcompose.v2.ListSchedulerEventsResponse
-	67,  // 429: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:output_type -> agentcompose.v2.ListProjectSchedulerEventsResponse
-	262, // 430: agentcompose.v2.ProjectService.StreamProjectSchedulerEvents:output_type -> agentcompose.v2.StreamProjectSchedulerEventsResponse
-	69,  // 431: agentcompose.v2.ProjectService.InvokeScheduler:output_type -> agentcompose.v2.InvokeSchedulerResponse
-	71,  // 432: agentcompose.v2.ProjectService.RunScheduler:output_type -> agentcompose.v2.RunSchedulerResponse
-	73,  // 433: agentcompose.v2.ProjectService.StartSchedulerRun:output_type -> agentcompose.v2.StartSchedulerRunResponse
-	75,  // 434: agentcompose.v2.ProjectService.GetSchedulerRun:output_type -> agentcompose.v2.GetSchedulerRunResponse
-	77,  // 435: agentcompose.v2.ProjectService.ListSchedulerRuns:output_type -> agentcompose.v2.ListSchedulerRunsResponse
-	267, // 436: agentcompose.v2.ProjectService.BatchGetLatestSchedulerRuns:output_type -> agentcompose.v2.BatchGetLatestSchedulerRunsResponse
-	264, // 437: agentcompose.v2.ProjectService.StreamSchedulerRuns:output_type -> agentcompose.v2.StreamSchedulerRunsResponse
-	81,  // 438: agentcompose.v2.ProjectService.PruneSchedulerRuns:output_type -> agentcompose.v2.PruneSchedulerRunsResponse
-	83,  // 439: agentcompose.v2.ProjectService.StopSchedulerRun:output_type -> agentcompose.v2.StopSchedulerRunResponse
-	86,  // 440: agentcompose.v2.ProjectService.SetSchedulerEnabled:output_type -> agentcompose.v2.SetSchedulerEnabledResponse
-	88,  // 441: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:output_type -> agentcompose.v2.SetSchedulerTriggerEnabledResponse
-	112, // 442: agentcompose.v2.RunService.RunAgent:output_type -> agentcompose.v2.RunAgentResponse
-	216, // 443: agentcompose.v2.RunService.StartAgentRun:output_type -> agentcompose.v2.StartAgentRunResponse
-	113, // 444: agentcompose.v2.RunService.StreamAgentRun:output_type -> agentcompose.v2.StreamAgentRunResponse
-	115, // 445: agentcompose.v2.RunService.AttachAgentRun:output_type -> agentcompose.v2.AttachAgentRunResponse
-	119, // 446: agentcompose.v2.RunService.GetRun:output_type -> agentcompose.v2.GetRunResponse
-	121, // 447: agentcompose.v2.RunService.ListRuns:output_type -> agentcompose.v2.ListRunsResponse
-	123, // 448: agentcompose.v2.RunService.FollowRunLogs:output_type -> agentcompose.v2.RunLogChunk
-	125, // 449: agentcompose.v2.RunService.StopRun:output_type -> agentcompose.v2.StopRunResponse
-	128, // 450: agentcompose.v2.RunService.ListRunEvents:output_type -> agentcompose.v2.ListRunEventsResponse
-	130, // 451: agentcompose.v2.RunService.ListSandboxRunEvents:output_type -> agentcompose.v2.ListSandboxRunEventsResponse
-	156, // 452: agentcompose.v2.ExecService.Exec:output_type -> agentcompose.v2.ExecResponse
-	157, // 453: agentcompose.v2.ExecService.StreamExec:output_type -> agentcompose.v2.StreamExecResponse
-	159, // 454: agentcompose.v2.ExecService.AttachExec:output_type -> agentcompose.v2.AttachExecResponse
-	176, // 455: agentcompose.v2.ImageService.ListImages:output_type -> agentcompose.v2.ListImagesResponse
-	178, // 456: agentcompose.v2.ImageService.PullImage:output_type -> agentcompose.v2.PullImageResponse
-	180, // 457: agentcompose.v2.ImageService.InspectImage:output_type -> agentcompose.v2.InspectImageResponse
-	182, // 458: agentcompose.v2.ImageService.RemoveImage:output_type -> agentcompose.v2.RemoveImageResponse
-	184, // 459: agentcompose.v2.ImageService.BuildImage:output_type -> agentcompose.v2.BuildImageEvent
-	187, // 460: agentcompose.v2.CacheService.ListCaches:output_type -> agentcompose.v2.ListCachesResponse
-	189, // 461: agentcompose.v2.CacheService.InspectCache:output_type -> agentcompose.v2.InspectCacheResponse
-	191, // 462: agentcompose.v2.CacheService.PruneCaches:output_type -> agentcompose.v2.PruneCachesResponse
-	193, // 463: agentcompose.v2.CacheService.RemoveCache:output_type -> agentcompose.v2.RemoveCacheResponse
-	197, // 464: agentcompose.v2.VolumeService.ListVolumes:output_type -> agentcompose.v2.ListVolumesResponse
-	199, // 465: agentcompose.v2.VolumeService.CreateVolume:output_type -> agentcompose.v2.CreateVolumeResponse
-	201, // 466: agentcompose.v2.VolumeService.InspectVolume:output_type -> agentcompose.v2.InspectVolumeResponse
-	203, // 467: agentcompose.v2.VolumeService.RemoveVolume:output_type -> agentcompose.v2.RemoveVolumeResponse
-	205, // 468: agentcompose.v2.VolumeService.PruneVolumes:output_type -> agentcompose.v2.PruneVolumesResponse
-	132, // 469: agentcompose.v2.SandboxService.RemoveSandbox:output_type -> agentcompose.v2.RemoveSandboxResponse
-	135, // 470: agentcompose.v2.SandboxService.PruneSandboxes:output_type -> agentcompose.v2.PruneSandboxesResponse
-	137, // 471: agentcompose.v2.SandboxService.GetSandboxStats:output_type -> agentcompose.v2.GetSandboxStatsResponse
-	144, // 472: agentcompose.v2.SandboxService.GetSandbox:output_type -> agentcompose.v2.GetSandboxResponse
-	146, // 473: agentcompose.v2.SandboxService.StopSandbox:output_type -> agentcompose.v2.StopSandboxResponse
-	148, // 474: agentcompose.v2.SandboxService.ResumeSandbox:output_type -> agentcompose.v2.ResumeSandboxResponse
-	143, // 475: agentcompose.v2.SandboxService.ListSandboxes:output_type -> agentcompose.v2.ListSandboxesResponse
-	256, // 476: agentcompose.v2.SandboxService.ListSandboxHistory:output_type -> agentcompose.v2.ListSandboxHistoryResponse
-	258, // 477: agentcompose.v2.SandboxService.WatchSandbox:output_type -> agentcompose.v2.WatchSandboxResponse
-	225, // 478: agentcompose.v2.DashboardService.GetDashboardOverview:output_type -> agentcompose.v2.GetDashboardOverviewResponse
-	226, // 479: agentcompose.v2.DashboardService.WatchDashboardOverview:output_type -> agentcompose.v2.WatchDashboardOverviewResponse
-	228, // 480: agentcompose.v2.SettingsService.GetGlobalEnv:output_type -> agentcompose.v2.GetGlobalEnvResponse
-	230, // 481: agentcompose.v2.SettingsService.UpdateGlobalEnv:output_type -> agentcompose.v2.UpdateGlobalEnvResponse
-	233, // 482: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:output_type -> agentcompose.v2.GetCapabilityGatewayConfigResponse
-	235, // 483: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:output_type -> agentcompose.v2.UpdateCapabilityGatewayConfigResponse
-	238, // 484: agentcompose.v2.SettingsService.ListWorkspacePresets:output_type -> agentcompose.v2.ListWorkspacePresetsResponse
-	243, // 485: agentcompose.v2.SettingsService.CreateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
-	243, // 486: agentcompose.v2.SettingsService.UpdateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
-	242, // 487: agentcompose.v2.SettingsService.DeleteWorkspacePreset:output_type -> agentcompose.v2.DeleteWorkspacePresetResponse
-	245, // 488: agentcompose.v2.CapabilityService.GetCapabilityStatus:output_type -> agentcompose.v2.CapabilityStatusResponse
-	248, // 489: agentcompose.v2.CapabilityService.ListCapabilitySets:output_type -> agentcompose.v2.ListCapabilitySetsResponse
-	252, // 490: agentcompose.v2.CapabilityService.GetCapabilityCatalog:output_type -> agentcompose.v2.GetCapabilityCatalogResponse
-	271, // 491: agentcompose.v2.LLMService.CreateProvider:output_type -> agentcompose.v2.CreateProviderResponse
-	273, // 492: agentcompose.v2.LLMService.GetProvider:output_type -> agentcompose.v2.GetProviderResponse
-	275, // 493: agentcompose.v2.LLMService.ListProviders:output_type -> agentcompose.v2.ListProvidersResponse
-	277, // 494: agentcompose.v2.LLMService.UpdateProvider:output_type -> agentcompose.v2.UpdateProviderResponse
-	279, // 495: agentcompose.v2.LLMService.DeleteProvider:output_type -> agentcompose.v2.DeleteProviderResponse
-	260, // 496: agentcompose.v2.LLMService.Generate:output_type -> agentcompose.v2.GenerateLLMResponse
-	219, // 497: agentcompose.v2.ResourceService.ResolveID:output_type -> agentcompose.v2.ResolveResourceIDResponse
-	419, // [419:498] is the sub-list for method output_type
-	340, // [340:419] is the sub-list for method input_type
+	253, // 412: agentcompose.v2.CapabilityService.InvokeCapability:input_type -> agentcompose.v2.InvokeCapabilityRequest
+	272, // 413: agentcompose.v2.LLMService.CreateProvider:input_type -> agentcompose.v2.CreateProviderRequest
+	274, // 414: agentcompose.v2.LLMService.GetProvider:input_type -> agentcompose.v2.GetProviderRequest
+	276, // 415: agentcompose.v2.LLMService.ListProviders:input_type -> agentcompose.v2.ListProvidersRequest
+	278, // 416: agentcompose.v2.LLMService.UpdateProvider:input_type -> agentcompose.v2.UpdateProviderRequest
+	280, // 417: agentcompose.v2.LLMService.DeleteProvider:input_type -> agentcompose.v2.DeleteProviderRequest
+	261, // 418: agentcompose.v2.LLMService.Generate:input_type -> agentcompose.v2.GenerateLLMRequest
+	218, // 419: agentcompose.v2.ResourceService.ResolveID:input_type -> agentcompose.v2.ResolveResourceIDRequest
+	36,  // 420: agentcompose.v2.ProjectService.ValidateProject:output_type -> agentcompose.v2.ValidateProjectResponse
+	38,  // 421: agentcompose.v2.ProjectService.ApplyProject:output_type -> agentcompose.v2.ApplyProjectResponse
+	38,  // 422: agentcompose.v2.ProjectService.PatchProject:output_type -> agentcompose.v2.ApplyProjectResponse
+	41,  // 423: agentcompose.v2.ProjectService.GetProject:output_type -> agentcompose.v2.GetProjectResponse
+	43,  // 424: agentcompose.v2.ProjectService.ListProjects:output_type -> agentcompose.v2.ListProjectsResponse
+	45,  // 425: agentcompose.v2.ProjectService.RemoveProject:output_type -> agentcompose.v2.RemoveProjectResponse
+	47,  // 426: agentcompose.v2.ProjectService.WatchProject:output_type -> agentcompose.v2.WatchProjectResponse
+	58,  // 427: agentcompose.v2.ProjectService.GetScheduler:output_type -> agentcompose.v2.GetSchedulerResponse
+	62,  // 428: agentcompose.v2.ProjectService.ListSchedulers:output_type -> agentcompose.v2.ListSchedulersResponse
+	65,  // 429: agentcompose.v2.ProjectService.ListSchedulerEvents:output_type -> agentcompose.v2.ListSchedulerEventsResponse
+	67,  // 430: agentcompose.v2.ProjectService.ListProjectSchedulerEvents:output_type -> agentcompose.v2.ListProjectSchedulerEventsResponse
+	264, // 431: agentcompose.v2.ProjectService.StreamProjectSchedulerEvents:output_type -> agentcompose.v2.StreamProjectSchedulerEventsResponse
+	69,  // 432: agentcompose.v2.ProjectService.InvokeScheduler:output_type -> agentcompose.v2.InvokeSchedulerResponse
+	71,  // 433: agentcompose.v2.ProjectService.RunScheduler:output_type -> agentcompose.v2.RunSchedulerResponse
+	73,  // 434: agentcompose.v2.ProjectService.StartSchedulerRun:output_type -> agentcompose.v2.StartSchedulerRunResponse
+	75,  // 435: agentcompose.v2.ProjectService.GetSchedulerRun:output_type -> agentcompose.v2.GetSchedulerRunResponse
+	77,  // 436: agentcompose.v2.ProjectService.ListSchedulerRuns:output_type -> agentcompose.v2.ListSchedulerRunsResponse
+	269, // 437: agentcompose.v2.ProjectService.BatchGetLatestSchedulerRuns:output_type -> agentcompose.v2.BatchGetLatestSchedulerRunsResponse
+	266, // 438: agentcompose.v2.ProjectService.StreamSchedulerRuns:output_type -> agentcompose.v2.StreamSchedulerRunsResponse
+	81,  // 439: agentcompose.v2.ProjectService.PruneSchedulerRuns:output_type -> agentcompose.v2.PruneSchedulerRunsResponse
+	83,  // 440: agentcompose.v2.ProjectService.StopSchedulerRun:output_type -> agentcompose.v2.StopSchedulerRunResponse
+	86,  // 441: agentcompose.v2.ProjectService.SetSchedulerEnabled:output_type -> agentcompose.v2.SetSchedulerEnabledResponse
+	88,  // 442: agentcompose.v2.ProjectService.SetSchedulerTriggerEnabled:output_type -> agentcompose.v2.SetSchedulerTriggerEnabledResponse
+	112, // 443: agentcompose.v2.RunService.RunAgent:output_type -> agentcompose.v2.RunAgentResponse
+	216, // 444: agentcompose.v2.RunService.StartAgentRun:output_type -> agentcompose.v2.StartAgentRunResponse
+	113, // 445: agentcompose.v2.RunService.StreamAgentRun:output_type -> agentcompose.v2.StreamAgentRunResponse
+	115, // 446: agentcompose.v2.RunService.AttachAgentRun:output_type -> agentcompose.v2.AttachAgentRunResponse
+	119, // 447: agentcompose.v2.RunService.GetRun:output_type -> agentcompose.v2.GetRunResponse
+	121, // 448: agentcompose.v2.RunService.ListRuns:output_type -> agentcompose.v2.ListRunsResponse
+	123, // 449: agentcompose.v2.RunService.FollowRunLogs:output_type -> agentcompose.v2.RunLogChunk
+	125, // 450: agentcompose.v2.RunService.StopRun:output_type -> agentcompose.v2.StopRunResponse
+	128, // 451: agentcompose.v2.RunService.ListRunEvents:output_type -> agentcompose.v2.ListRunEventsResponse
+	130, // 452: agentcompose.v2.RunService.ListSandboxRunEvents:output_type -> agentcompose.v2.ListSandboxRunEventsResponse
+	156, // 453: agentcompose.v2.ExecService.Exec:output_type -> agentcompose.v2.ExecResponse
+	157, // 454: agentcompose.v2.ExecService.StreamExec:output_type -> agentcompose.v2.StreamExecResponse
+	159, // 455: agentcompose.v2.ExecService.AttachExec:output_type -> agentcompose.v2.AttachExecResponse
+	176, // 456: agentcompose.v2.ImageService.ListImages:output_type -> agentcompose.v2.ListImagesResponse
+	178, // 457: agentcompose.v2.ImageService.PullImage:output_type -> agentcompose.v2.PullImageResponse
+	180, // 458: agentcompose.v2.ImageService.InspectImage:output_type -> agentcompose.v2.InspectImageResponse
+	182, // 459: agentcompose.v2.ImageService.RemoveImage:output_type -> agentcompose.v2.RemoveImageResponse
+	184, // 460: agentcompose.v2.ImageService.BuildImage:output_type -> agentcompose.v2.BuildImageEvent
+	187, // 461: agentcompose.v2.CacheService.ListCaches:output_type -> agentcompose.v2.ListCachesResponse
+	189, // 462: agentcompose.v2.CacheService.InspectCache:output_type -> agentcompose.v2.InspectCacheResponse
+	191, // 463: agentcompose.v2.CacheService.PruneCaches:output_type -> agentcompose.v2.PruneCachesResponse
+	193, // 464: agentcompose.v2.CacheService.RemoveCache:output_type -> agentcompose.v2.RemoveCacheResponse
+	197, // 465: agentcompose.v2.VolumeService.ListVolumes:output_type -> agentcompose.v2.ListVolumesResponse
+	199, // 466: agentcompose.v2.VolumeService.CreateVolume:output_type -> agentcompose.v2.CreateVolumeResponse
+	201, // 467: agentcompose.v2.VolumeService.InspectVolume:output_type -> agentcompose.v2.InspectVolumeResponse
+	203, // 468: agentcompose.v2.VolumeService.RemoveVolume:output_type -> agentcompose.v2.RemoveVolumeResponse
+	205, // 469: agentcompose.v2.VolumeService.PruneVolumes:output_type -> agentcompose.v2.PruneVolumesResponse
+	132, // 470: agentcompose.v2.SandboxService.RemoveSandbox:output_type -> agentcompose.v2.RemoveSandboxResponse
+	135, // 471: agentcompose.v2.SandboxService.PruneSandboxes:output_type -> agentcompose.v2.PruneSandboxesResponse
+	137, // 472: agentcompose.v2.SandboxService.GetSandboxStats:output_type -> agentcompose.v2.GetSandboxStatsResponse
+	144, // 473: agentcompose.v2.SandboxService.GetSandbox:output_type -> agentcompose.v2.GetSandboxResponse
+	146, // 474: agentcompose.v2.SandboxService.StopSandbox:output_type -> agentcompose.v2.StopSandboxResponse
+	148, // 475: agentcompose.v2.SandboxService.ResumeSandbox:output_type -> agentcompose.v2.ResumeSandboxResponse
+	143, // 476: agentcompose.v2.SandboxService.ListSandboxes:output_type -> agentcompose.v2.ListSandboxesResponse
+	258, // 477: agentcompose.v2.SandboxService.ListSandboxHistory:output_type -> agentcompose.v2.ListSandboxHistoryResponse
+	260, // 478: agentcompose.v2.SandboxService.WatchSandbox:output_type -> agentcompose.v2.WatchSandboxResponse
+	225, // 479: agentcompose.v2.DashboardService.GetDashboardOverview:output_type -> agentcompose.v2.GetDashboardOverviewResponse
+	226, // 480: agentcompose.v2.DashboardService.WatchDashboardOverview:output_type -> agentcompose.v2.WatchDashboardOverviewResponse
+	228, // 481: agentcompose.v2.SettingsService.GetGlobalEnv:output_type -> agentcompose.v2.GetGlobalEnvResponse
+	230, // 482: agentcompose.v2.SettingsService.UpdateGlobalEnv:output_type -> agentcompose.v2.UpdateGlobalEnvResponse
+	233, // 483: agentcompose.v2.SettingsService.GetCapabilityGatewayConfig:output_type -> agentcompose.v2.GetCapabilityGatewayConfigResponse
+	235, // 484: agentcompose.v2.SettingsService.UpdateCapabilityGatewayConfig:output_type -> agentcompose.v2.UpdateCapabilityGatewayConfigResponse
+	238, // 485: agentcompose.v2.SettingsService.ListWorkspacePresets:output_type -> agentcompose.v2.ListWorkspacePresetsResponse
+	243, // 486: agentcompose.v2.SettingsService.CreateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
+	243, // 487: agentcompose.v2.SettingsService.UpdateWorkspacePreset:output_type -> agentcompose.v2.WorkspacePresetResponse
+	242, // 488: agentcompose.v2.SettingsService.DeleteWorkspacePreset:output_type -> agentcompose.v2.DeleteWorkspacePresetResponse
+	245, // 489: agentcompose.v2.CapabilityService.GetCapabilityStatus:output_type -> agentcompose.v2.CapabilityStatusResponse
+	248, // 490: agentcompose.v2.CapabilityService.ListCapabilitySets:output_type -> agentcompose.v2.ListCapabilitySetsResponse
+	252, // 491: agentcompose.v2.CapabilityService.GetCapabilityCatalog:output_type -> agentcompose.v2.GetCapabilityCatalogResponse
+	254, // 492: agentcompose.v2.CapabilityService.InvokeCapability:output_type -> agentcompose.v2.InvokeCapabilityResponse
+	273, // 493: agentcompose.v2.LLMService.CreateProvider:output_type -> agentcompose.v2.CreateProviderResponse
+	275, // 494: agentcompose.v2.LLMService.GetProvider:output_type -> agentcompose.v2.GetProviderResponse
+	277, // 495: agentcompose.v2.LLMService.ListProviders:output_type -> agentcompose.v2.ListProvidersResponse
+	279, // 496: agentcompose.v2.LLMService.UpdateProvider:output_type -> agentcompose.v2.UpdateProviderResponse
+	281, // 497: agentcompose.v2.LLMService.DeleteProvider:output_type -> agentcompose.v2.DeleteProviderResponse
+	262, // 498: agentcompose.v2.LLMService.Generate:output_type -> agentcompose.v2.GenerateLLMResponse
+	219, // 499: agentcompose.v2.ResourceService.ResolveID:output_type -> agentcompose.v2.ResolveResourceIDResponse
+	420, // [420:500] is the sub-list for method output_type
+	340, // [340:420] is the sub-list for method input_type
 	340, // [340:340] is the sub-list for extension type_name
 	340, // [340:340] is the sub-list for extension extendee
 	0,   // [0:340] is the sub-list for field type_name
@@ -22404,14 +22565,14 @@ func file_agentcompose_v2_agentcompose_proto_init() {
 		(*AttachExecResponse_AgentTurnCompleted)(nil),
 	}
 	file_agentcompose_v2_agentcompose_proto_msgTypes[199].OneofWrappers = []any{}
-	file_agentcompose_v2_agentcompose_proto_msgTypes[234].OneofWrappers = []any{}
+	file_agentcompose_v2_agentcompose_proto_msgTypes[236].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_agentcompose_v2_agentcompose_proto_rawDesc), len(file_agentcompose_v2_agentcompose_proto_rawDesc)),
 			NumEnums:      35,
-			NumMessages:   260,
+			NumMessages:   262,
 			NumExtensions: 0,
 			NumServices:   12,
 		},

--- a/proto/agentcompose/v2/agentcompose.proto
+++ b/proto/agentcompose/v2/agentcompose.proto
@@ -143,6 +143,7 @@ service CapabilityService {
   rpc GetCapabilityStatus(GetCapabilityStatusRequest) returns (CapabilityStatusResponse);
   rpc ListCapabilitySets(ListCapabilitySetsRequest) returns (ListCapabilitySetsResponse);
   rpc GetCapabilityCatalog(GetCapabilityCatalogRequest) returns (GetCapabilityCatalogResponse);
+  rpc InvokeCapability(InvokeCapabilityRequest) returns (InvokeCapabilityResponse);
 }
 
 service LLMService {
@@ -2031,14 +2032,19 @@ message UpdateGlobalEnvResponse { repeated EnvVarSpec env = 1; }
 message GetCapabilityGatewayConfigRequest {}
 message CapabilityGatewayConfig {
   string addr = 1;
+  // Whether the capset token used for business capability invocation is set.
   bool token_set = 2;
+  // Whether the OctoBus admin token used for status/catalog access is set.
+  bool admin_token_set = 3;
 }
 message GetCapabilityGatewayConfigResponse { CapabilityGatewayConfig config = 1; }
 message UpdateCapabilityGatewayConfigRequest {
   // Field patch: absent is no-op; present empty explicitly clears the address.
   optional string addr = 1;
-  // Field patch: absent is no-op; present empty explicitly clears the token.
+  // Field patch: absent is no-op; present empty explicitly clears the capset token.
   optional string token = 2;
+  // Field patch: absent is no-op; present empty explicitly clears the admin token.
+  optional string admin_token = 3;
 }
 message UpdateCapabilityGatewayConfigResponse { CapabilityGatewayConfig config = 1; }
 
@@ -2139,6 +2145,19 @@ message GetCapabilityCatalogResponse {
   string name = 2;
   string description = 3;
   repeated CapabilityMethod methods = 4;
+}
+
+message InvokeCapabilityRequest {
+  string capset_id = 1;
+  string instance_id = 2;
+  string service_id = 3;
+  string method = 4;
+  // JSON-encoded request object forwarded to the OctoBus Connect RPC method.
+  string payload_json = 5;
+}
+message InvokeCapabilityResponse {
+  // JSON-encoded response object returned by the OctoBus Connect RPC method.
+  string result_json = 1;
 }
 
 message ListSandboxHistoryRequest {

--- a/proto/agentcompose/v2/agentcomposev2connect/agentcompose.connect.go
+++ b/proto/agentcompose/v2/agentcomposev2connect/agentcompose.connect.go
@@ -260,6 +260,9 @@ const (
 	// CapabilityServiceGetCapabilityCatalogProcedure is the fully-qualified name of the
 	// CapabilityService's GetCapabilityCatalog RPC.
 	CapabilityServiceGetCapabilityCatalogProcedure = "/agentcompose.v2.CapabilityService/GetCapabilityCatalog"
+	// CapabilityServiceInvokeCapabilityProcedure is the fully-qualified name of the CapabilityService's
+	// InvokeCapability RPC.
+	CapabilityServiceInvokeCapabilityProcedure = "/agentcompose.v2.CapabilityService/InvokeCapability"
 	// LLMServiceCreateProviderProcedure is the fully-qualified name of the LLMService's CreateProvider
 	// RPC.
 	LLMServiceCreateProviderProcedure = "/agentcompose.v2.LLMService/CreateProvider"
@@ -2549,6 +2552,7 @@ type CapabilityServiceClient interface {
 	GetCapabilityStatus(context.Context, *connect.Request[v2.GetCapabilityStatusRequest]) (*connect.Response[v2.CapabilityStatusResponse], error)
 	ListCapabilitySets(context.Context, *connect.Request[v2.ListCapabilitySetsRequest]) (*connect.Response[v2.ListCapabilitySetsResponse], error)
 	GetCapabilityCatalog(context.Context, *connect.Request[v2.GetCapabilityCatalogRequest]) (*connect.Response[v2.GetCapabilityCatalogResponse], error)
+	InvokeCapability(context.Context, *connect.Request[v2.InvokeCapabilityRequest]) (*connect.Response[v2.InvokeCapabilityResponse], error)
 }
 
 // NewCapabilityServiceClient constructs a client for the agentcompose.v2.CapabilityService service.
@@ -2580,6 +2584,12 @@ func NewCapabilityServiceClient(httpClient connect.HTTPClient, baseURL string, o
 			connect.WithSchema(capabilityServiceMethods.ByName("GetCapabilityCatalog")),
 			connect.WithClientOptions(opts...),
 		),
+		invokeCapability: connect.NewClient[v2.InvokeCapabilityRequest, v2.InvokeCapabilityResponse](
+			httpClient,
+			baseURL+CapabilityServiceInvokeCapabilityProcedure,
+			connect.WithSchema(capabilityServiceMethods.ByName("InvokeCapability")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -2588,6 +2598,7 @@ type capabilityServiceClient struct {
 	getCapabilityStatus  *connect.Client[v2.GetCapabilityStatusRequest, v2.CapabilityStatusResponse]
 	listCapabilitySets   *connect.Client[v2.ListCapabilitySetsRequest, v2.ListCapabilitySetsResponse]
 	getCapabilityCatalog *connect.Client[v2.GetCapabilityCatalogRequest, v2.GetCapabilityCatalogResponse]
+	invokeCapability     *connect.Client[v2.InvokeCapabilityRequest, v2.InvokeCapabilityResponse]
 }
 
 // GetCapabilityStatus calls agentcompose.v2.CapabilityService.GetCapabilityStatus.
@@ -2605,11 +2616,17 @@ func (c *capabilityServiceClient) GetCapabilityCatalog(ctx context.Context, req 
 	return c.getCapabilityCatalog.CallUnary(ctx, req)
 }
 
+// InvokeCapability calls agentcompose.v2.CapabilityService.InvokeCapability.
+func (c *capabilityServiceClient) InvokeCapability(ctx context.Context, req *connect.Request[v2.InvokeCapabilityRequest]) (*connect.Response[v2.InvokeCapabilityResponse], error) {
+	return c.invokeCapability.CallUnary(ctx, req)
+}
+
 // CapabilityServiceHandler is an implementation of the agentcompose.v2.CapabilityService service.
 type CapabilityServiceHandler interface {
 	GetCapabilityStatus(context.Context, *connect.Request[v2.GetCapabilityStatusRequest]) (*connect.Response[v2.CapabilityStatusResponse], error)
 	ListCapabilitySets(context.Context, *connect.Request[v2.ListCapabilitySetsRequest]) (*connect.Response[v2.ListCapabilitySetsResponse], error)
 	GetCapabilityCatalog(context.Context, *connect.Request[v2.GetCapabilityCatalogRequest]) (*connect.Response[v2.GetCapabilityCatalogResponse], error)
+	InvokeCapability(context.Context, *connect.Request[v2.InvokeCapabilityRequest]) (*connect.Response[v2.InvokeCapabilityResponse], error)
 }
 
 // NewCapabilityServiceHandler builds an HTTP handler from the service implementation. It returns
@@ -2637,6 +2654,12 @@ func NewCapabilityServiceHandler(svc CapabilityServiceHandler, opts ...connect.H
 		connect.WithSchema(capabilityServiceMethods.ByName("GetCapabilityCatalog")),
 		connect.WithHandlerOptions(opts...),
 	)
+	capabilityServiceInvokeCapabilityHandler := connect.NewUnaryHandler(
+		CapabilityServiceInvokeCapabilityProcedure,
+		svc.InvokeCapability,
+		connect.WithSchema(capabilityServiceMethods.ByName("InvokeCapability")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/agentcompose.v2.CapabilityService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case CapabilityServiceGetCapabilityStatusProcedure:
@@ -2645,6 +2668,8 @@ func NewCapabilityServiceHandler(svc CapabilityServiceHandler, opts ...connect.H
 			capabilityServiceListCapabilitySetsHandler.ServeHTTP(w, r)
 		case CapabilityServiceGetCapabilityCatalogProcedure:
 			capabilityServiceGetCapabilityCatalogHandler.ServeHTTP(w, r)
+		case CapabilityServiceInvokeCapabilityProcedure:
+			capabilityServiceInvokeCapabilityHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -2664,6 +2689,10 @@ func (UnimplementedCapabilityServiceHandler) ListCapabilitySets(context.Context,
 
 func (UnimplementedCapabilityServiceHandler) GetCapabilityCatalog(context.Context, *connect.Request[v2.GetCapabilityCatalogRequest]) (*connect.Response[v2.GetCapabilityCatalogResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.CapabilityService.GetCapabilityCatalog is not implemented"))
+}
+
+func (UnimplementedCapabilityServiceHandler) InvokeCapability(context.Context, *connect.Request[v2.InvokeCapabilityRequest]) (*connect.Response[v2.InvokeCapabilityResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("agentcompose.v2.CapabilityService.InvokeCapability is not implemented"))
 }
 
 // LLMServiceClient is a client for the agentcompose.v2.LLMService service.


### PR DESCRIPTION
## 变更

- 修复 OpenAI Chat 流式 `tool_calls` 桥接到 Responses 协议时，未发送 `response.function_call_arguments.done` 和 `response.output_item.done` 的问题。
- 缓冲分片参数，在流结束时生成完整工具调用，确保 Codex 能实际执行工具。
- 增加先红后绿的协议桥回归测试。

## 验证

- `go test ./pkg/llms ./pkg/agentcompose/proxy -count=1` 通过。
- 真实 DeepSeek 自主 shell 调用通过。
- 真实 OC `IpReputation` 调用到达 OC 与微步上游，上游额度返回被正确保留。

说明：`go test ./...` 中既有 macOS 路径、时区和 Unix socket E2E 环境失败，与本次改动无关。